### PR TITLE
Initial version of a (very) basic IsoSeq pipeline.

### DIFF
--- a/data/LRTranscriptomeSingleSample/SM-HLD5O.json
+++ b/data/LRTranscriptomeSingleSample/SM-HLD5O.json
@@ -1,0 +1,12 @@
+{
+    "LRTranscriptomeSingleSample.gcs_dirs": [
+        "gs://broad-dsde-methods-long-reads-incoming/PDO-19423_IsoSeq/SM-HLD5O-Cell1/",
+        "gs://broad-dsde-methods-long-reads-incoming/PDO-19423_IsoSeq/SM-HLD5O-Cell2/"
+    ],
+
+    "LRTranscriptomeSingleSample.sample_name": "SM-HLD5O",
+
+    "LRTranscriptomeSingleSample.ref_fasta":     "gs://broad-dsde-methods-long-reads/resources/references/grch38/Homo_sapiens_assembly38.fasta",
+    "LRTranscriptomeSingleSample.ref_fasta_fai": "gs://broad-dsde-methods-long-reads/resources/references/grch38/Homo_sapiens_assembly38.fasta.fai",
+    "LRTranscriptomeSingleSample.ref_dict":      "gs://broad-dsde-methods-long-reads/resources/references/grch38/Homo_sapiens_assembly38.dict"
+}

--- a/data/LRTranscriptomeSingleSample/SM-HLD5O.json
+++ b/data/LRTranscriptomeSingleSample/SM-HLD5O.json
@@ -8,5 +8,7 @@
 
     "LRTranscriptomeSingleSample.ref_fasta":     "gs://broad-dsde-methods-long-reads/resources/references/grch38/Homo_sapiens_assembly38.fasta",
     "LRTranscriptomeSingleSample.ref_fasta_fai": "gs://broad-dsde-methods-long-reads/resources/references/grch38/Homo_sapiens_assembly38.fasta.fai",
-    "LRTranscriptomeSingleSample.ref_dict":      "gs://broad-dsde-methods-long-reads/resources/references/grch38/Homo_sapiens_assembly38.dict"
+    "LRTranscriptomeSingleSample.ref_dict":      "gs://broad-dsde-methods-long-reads/resources/references/grch38/Homo_sapiens_assembly38.dict",
+
+    "LRTranscriptomeSingleSample.gcs_output_dir": "gs://broad-dsde-methods-long-reads-outgoing/LRTranscriptomeSingleSample"
 }

--- a/data/LRTranscriptomeSingleSample/SM-HLD5P.json
+++ b/data/LRTranscriptomeSingleSample/SM-HLD5P.json
@@ -8,5 +8,7 @@
 
     "LRTranscriptomeSingleSample.ref_fasta":     "gs://broad-dsde-methods-long-reads/resources/references/grch38/Homo_sapiens_assembly38.fasta",
     "LRTranscriptomeSingleSample.ref_fasta_fai": "gs://broad-dsde-methods-long-reads/resources/references/grch38/Homo_sapiens_assembly38.fasta.fai",
-    "LRTranscriptomeSingleSample.ref_dict":      "gs://broad-dsde-methods-long-reads/resources/references/grch38/Homo_sapiens_assembly38.dict"
+    "LRTranscriptomeSingleSample.ref_dict":      "gs://broad-dsde-methods-long-reads/resources/references/grch38/Homo_sapiens_assembly38.dict",
+
+    "LRTranscriptomeSingleSample.gcs_output_dir": "gs://broad-dsde-methods-long-reads-outgoing/LRTranscriptomeSingleSample"
 }

--- a/data/LRTranscriptomeSingleSample/SM-HLD5P.json
+++ b/data/LRTranscriptomeSingleSample/SM-HLD5P.json
@@ -1,0 +1,12 @@
+{
+    "LRTranscriptomeSingleSample.gcs_dirs": [
+        "gs://broad-dsde-methods-long-reads-incoming/PDO-19423_IsoSeq/SM-HLD5P-Cell1/",
+        "gs://broad-dsde-methods-long-reads-incoming/PDO-19423_IsoSeq/SM-HLD5P-Cell2/"
+    ],
+
+    "LRTranscriptomeSingleSample.sample_name": "SM-HLD5P",
+
+    "LRTranscriptomeSingleSample.ref_fasta":     "gs://broad-dsde-methods-long-reads/resources/references/grch38/Homo_sapiens_assembly38.fasta",
+    "LRTranscriptomeSingleSample.ref_fasta_fai": "gs://broad-dsde-methods-long-reads/resources/references/grch38/Homo_sapiens_assembly38.fasta.fai",
+    "LRTranscriptomeSingleSample.ref_dict":      "gs://broad-dsde-methods-long-reads/resources/references/grch38/Homo_sapiens_assembly38.dict"
+}

--- a/wdl/AlignReads.wdl
+++ b/wdl/AlignReads.wdl
@@ -31,7 +31,7 @@ task Minimap2 {
         set -euxo pipefail
 
         RG=`python /usr/local/bin/merge_read_group_tags.py --ID ~{ID} --SM ~{SM} --PL ~{PL} ~{shard}`
-        samtools fastq ~{shard} | minimap2 -ayY --MD --eqx -x ~{correction_arg} -R ${RG} -t ~{cpus} ~{ref_fasta} - | samtools view -b - > temp.aligned.unsorted.bam
+        samtools fastq ~{shard} | minimap2 -ayY --MD --eqx -x ~{map_preset} -R ${RG} -t ~{cpus} ~{ref_fasta} - | samtools view -b - > temp.aligned.unsorted.bam
         java -Dsamjdk.compression_level=0 -Xmx4g -jar /usr/local/bin/gatk.jar RepairLongReadBam -I ~{shard} -A temp.aligned.unsorted.bam -O temp.aligned.unsorted.repaired.bam -DF WellformedReadFilter --use-jdk-deflater --use-jdk-inflater
         samtools sort -@~{cpus} -m4G -o ~{aligned_shard_name} temp.aligned.unsorted.repaired.bam
     >>>

--- a/wdl/AlignReads.wdl
+++ b/wdl/AlignReads.wdl
@@ -11,13 +11,16 @@ task Minimap2 {
         String ID
         String PL
         Boolean? reads_are_corrected
+        Boolean? reads_are_rna
         
         RuntimeAttr? runtime_attr_override
     }
 
     Boolean correct = select_first([reads_are_corrected, false])
+    Boolean rna_reads = select_first([reads_are_rna, false])
     String map_arg = if (PL == "ONT") then "map-ont" else "map-pb"
     String correction_arg = if (correct) then "asm20" else map_arg
+    String map_preset = if (rna_reads) then "splice" else correction_arg
 
     Int cpus = 4
     Int disk_size = ceil(size(ref_fasta, "GB")) + 4*ceil(size(shard, "GB"))

--- a/wdl/LRTranscriptomeSingleSample.wdl
+++ b/wdl/LRTranscriptomeSingleSample.wdl
@@ -48,6 +48,8 @@ workflow LRTranscriptomeSingleSample {
         File ref_fasta
         File ref_fasta_fai
         File ref_dict
+
+        String gcs_output_dir
     }
 
     scatter (gcs_dir in gcs_dirs) {
@@ -65,6 +67,7 @@ workflow LRTranscriptomeSingleSample {
         call SLR.ShardLongReads as ShardLongReads {
             input:
                 unmapped_bam = PrepareRun.unmapped_bam,
+                num_reads_per_split = 2000000
         }
 
         scatter (unmapped_shard in ShardLongReads.unmapped_shards) {

--- a/wdl/LRTranscriptomeSingleSample.wdl
+++ b/wdl/LRTranscriptomeSingleSample.wdl
@@ -1,0 +1,140 @@
+version 1.0
+
+# Copyright Broad Institute, 2019
+#
+# About:
+#   This WDL pipeline processes long read RNA data from a single sample (which may be split among multiple
+#   PacBio SMRTCells).  We perform a variety of tasks (including CCS error correction, alignment,
+#   flowcell merging, and automated QC). The results of pipeline are intended to be "analysis-ready".
+#
+#   This pipeline is currently capable of processing any combination of the following datasets:
+#     - PacBio raw CCS IsoSeq data
+#
+#   Data may be presented as a PacBio run directory or just a collection of BAM/fastq files.  Generally the
+#   data type and sample information are autodetected, but can also be manually overridden in the input JSON file.
+#
+#
+# Description of inputs:
+#   Required:
+#       Array[String] gcs_dirs          - The GCS directories wherein the data is stored.
+#       File ref_fasta                  - The reference genome to which reads should be aligned.
+#       File ref_fasta_fai              - The .fai index for the reference genome.
+#       File ref_dict                   - The sequence dictionary for the reference genome.
+#
+#   Optional:
+#       String sample_name              - The sample name to use in place of the autodetected name.
+#
+#
+# Licensing:
+#   This script is released under the WDL source code license (BSD-3) (see LICENSE in
+#   https://github.com/broadinstitute/wdl). Note however that the programs it calls may be subject to different
+#   licenses. Users are responsible for checking that they are authorized to run all programs before running
+#   this script.
+
+import "AlignReads.wdl" as AR
+import "CorrectReads.wdl" as CR
+import "MergeBams.wdl" as MB
+import "RecoverCCSRemainingReads.wdl" as RCCSRR
+import "ShardLongReads.wdl" as SLR
+import "Utils.wdl" as Utils
+import "ValidateBam.wdl" as VB
+
+workflow LRTranscriptomeSingleSample {
+    input {
+        Array[String] gcs_dirs
+
+        String? sample_name
+
+        File ref_fasta
+        File ref_fasta_fai
+        File ref_dict
+    }
+
+    scatter (gcs_dir in gcs_dirs) {
+        call Utils.DetectRunInfo as DetectRunInfo {
+            input:
+                gcs_dir = gcs_dir,
+                sample_name = sample_name,
+        }
+
+        call Utils.PrepareRun as PrepareRun {
+            input:
+                files = DetectRunInfo.files,
+        }
+
+        call SLR.ShardLongReads as ShardLongReads {
+            input:
+                unmapped_bam = PrepareRun.unmapped_bam,
+        }
+
+        scatter (unmapped_shard in ShardLongReads.unmapped_shards) {
+            call CR.CCS as CCS {
+                input:
+                    unmapped_shard = unmapped_shard,
+                    platform = DetectRunInfo.run_info['PL'],
+            }
+
+            call AR.Minimap2 as AlignCCS {
+                input:
+                    shard = CCS.ccs_shard,
+                    ref_fasta = ref_fasta,
+                    SM = DetectRunInfo.run_info['SM'],
+                    ID = DetectRunInfo.run_info['ID'] + ".corrected",
+                    PL = DetectRunInfo.run_info['PL'],
+                    reads_are_corrected = true,
+                    reads_are_rna = true,
+            }
+
+            call RCCSRR.RecoverCCSRemainingReads as RecoverCCSRemainingReads {
+                input:
+                    unmapped_shard = unmapped_shard,
+                    ccs_shard = CCS.ccs_shard,
+            }
+
+            call AR.Minimap2 as AlignRemaining {
+                input:
+                    shard = RecoverCCSRemainingReads.remaining_shard,
+                    ref_fasta = ref_fasta,
+                    SM = DetectRunInfo.run_info['SM'],
+                    ID = DetectRunInfo.run_info['ID'] + ".remaining",
+                    PL = DetectRunInfo.run_info['PL'],
+                    reads_are_corrected = false,
+                    reads_are_rna = true,
+            }
+        }
+
+        call MB.MergeBams as MergeCorrected {
+            input:
+                aligned_shards = AlignCCS.aligned_shard,
+                merged_name="corrected.bam",
+        }
+
+        call MB.MergeBams as MergeRemaining {
+            input:
+                aligned_shards = AlignRemaining.aligned_shard,
+                merged_name="remaining.bam",
+        }
+    }
+
+    call MB.MergeBams as MergeAllCorrected {
+        input:
+            aligned_shards = MergeCorrected.merged,
+            merged_name="all.corrected.bam",
+    }
+
+    call VB.ValidateBam as ValidateAllCorrected {
+        input:
+            input_bam = MergeAllCorrected.merged,
+    }
+
+    call MB.MergeBams as MergeAllRemaining {
+        input:
+            aligned_shards = MergeRemaining.merged,
+            merged_name="all.remaining.bam",
+    }
+
+    call VB.ValidateBam as ValidateAllRemaining {
+        input:
+            input_bam = MergeAllRemaining.merged,
+    }
+}


### PR DESCRIPTION
This pipeline is mostly a copy of the LRWholeGenomeSingleSample pipeline.  It shards, corrects, aligns, and merges RNA data.  Minor but notable differences to the LRWholeGenomeSingleSample are:

* sharding into BAMs with ~2e6 reads (IsoSeq reads are ~2kb, so the standard sharding at ~2e5 reads results in way too many files).
* alignment is conducted using minimap2's splice-aware mode.