### PR TITLE
update the trio binning (canu) workflow significantly

### DIFF
--- a/scripts/vm_local_monitoring_script.sh
+++ b/scripts/vm_local_monitoring_script.sh
@@ -1,0 +1,305 @@
+#!/bin/bash
+
+# ADDED NOTE: this script is intended to be localized to your google cloud 
+# vm and run in the following fashion to get resources usage
+# ```
+# export MONITOR_MOUNT_POINT=${your_home_dir_or_cromwell_root}
+# bash vm_local_monitoring_script.sh &> resources.log &
+# job_id=$(ps -aux | grep -F 'vm_local_monitoring_script.sh' | head -1 | awk '{print $2}')
+# ${you_resource_intensive_jobs}
+# # we recommend only run the following if manually launched
+# kill $job_id
+# # if running on a cromwell providisioned VM
+# # remember to delocalize the "resources.log"
+# ```
+
+
+# NOTE: this script is intended to be placed in google cloud storage
+# and invoked by adding the following line to your cromwell workflow
+# options:
+#    "monitoring_script": "gs://bucket/path/to/cromwell_monitoring_script.sh"
+# Upon task completion "monitoring.log" will be added to the appropriate
+# cloud storage folder.
+set -Eeuo pipefail
+
+MONITOR_MOUNT_POINT=${MONITOR_MOUNT_POINT:-"/"}
+SLEEP_TIME=${SLEEP_TIME:-"10"}
+
+function getCpuUsage() {
+    # get the summary cpu statistics (i.e. for all cpus) since boot
+    # get the numeric values in an array, dropping the first field (the
+    # string, "cpu")
+    CPU_TIMES=(`sed -n 's/^cpu\s//p' /proc/stat`)
+    # idle time (in system units) is the 3rd numeric field
+    IDLE_TIME=${CPU_TIMES[3]}
+    # total cpu time is sum of all fields
+    TOTAL_TIME=0
+    for T in ${CPU_TIMES[@]}; do
+        ((TOTAL_TIME += T))
+    done
+    
+    # get the previous times from temp file
+    read PREVIOUS_IDLE PREVIOUS_TOTAL < $TEMP_CPU
+    
+    # write current times to temp file
+    echo "$IDLE_TIME $TOTAL_TIME" > $TEMP_CPU
+    
+    # get the difference in idle and total times since the previous
+    # update, and report the usage as: non-idle time as a percentage
+    # of total time
+    awk -v IDLE=$((IDLE_TIME-PREVIOUS_IDLE)) \
+        -v TOTAL=$((TOTAL_TIME-PREVIOUS_TOTAL)) \
+        'BEGIN { printf "%.1f%%", 100 * (1 - IDLE / TOTAL) }'
+}
+
+function getMem() {
+    # get desired memory value from /proc/meminfo, in GiB, and also
+    # as a percentage of total
+    # argument is the label of the desired memory value
+    cat /proc/meminfo \
+        | awk -v MEM_FIELD="$1" '{
+            f[substr($1, 1, length($1)-1)] = $2
+        } END {
+            printf "%.2f GiB", f[MEM_FIELD] / 1048576
+        }'     
+}
+
+function getMemUnavailable() {
+    # get unavailable memory from /proc/meminfo, in GiB
+    cat /proc/meminfo \
+        | awk '{
+            f[substr($1, 1, length($1)-1)] = $2
+        } END {
+            
+            if("MemAvailable" in f) {
+                mem_available = f["MemAvailable"]
+            } else {
+                mem_available = f["MemFree"] + f["Buffers"] + f["Cached"]
+            }
+            mem_in_use = f["MemTotal"] - mem_available
+            printf "%.2f GiB %.1f%%", mem_in_use / 1048576, 100 * mem_in_use / f["MemTotal"] 
+        }'    
+}
+
+# old version using "free -m" are kept in case a container somehow has
+# weird values in /proc/meminfo
+function getMem_with_free() {
+    # get memory info from "free" command. Convert to float in GB.
+    # First argument is desired row of output table.
+    # Second argument is desired column.
+    MEM_ROW=$(echo "$1" | awk '{print tolower($1)}')
+    MEM_COLUMN=$(echo "$2" | awk '{print tolower($1)}')
+    free -m | awk -v MEM_ROW=$MEM_ROW -v MEM_COLUMN=$MEM_COLUMN \
+        'NR=1 {
+            for(i=1; i<=NF; i++) { f[tolower($i)]=NF+1-i }
+        }
+        {
+            regex="^"MEM_ROW
+            if(tolower($1) ~ regex) {
+                print $(NF+1-f[MEM_COLUMN])/1024 " GiB"
+            }
+        }'
+}
+
+# old version using "free -m" are kept in case a container somehow has
+# weird values in /proc/meminfo
+function getMemUnavailable_using_free() {
+    # get memory that is in active use (not just cached) from "free"
+    # command. Convert to float in GiB, followed by percent of total.
+    # NOTE: weird computation with awk due to variety of output from
+    # free on different systems. Rows and columns differ, and on some
+    # systems the desired quantity is used "used" memory, on most it's
+    # "used" - "buffers" - "cached". If "buffers" and "cached" don't
+    # exist, then awk will subtract 0 so the correct result is returned.
+    free -m \
+        | awk '\
+            NR=1 {
+                for(i=1; i<=NF; i++) { f[tolower($i)]=NF+1-i }
+            }
+            {
+                if(tolower($1) ~ "^mem") {
+                    IN_USE=($(NF+1-f["used"]) - $(NF+1-f["buffers"]) - $(NF+1-f["cached"]))
+                    printf "%.3f GiB %.1f%%", IN_USE/1024, 100*IN_USE/$(NF+1-f["total"])
+                }
+            }'
+}
+
+
+function getDisk() {
+    # get information about disk usage from "df" command.
+    DISK_COLUMN=$(echo "$1" | awk '{print tolower($1)}')
+    MOUNT_POINT=$2
+    # extract desired value
+    VALUE=$(\
+        df -h "$MOUNT_POINT" \
+        | sed 's/Mounted on/Mounted-on/' \
+        | awk -v DISK_COLUMN=$DISK_COLUMN '
+            FNR==1 {
+                NF_HEADER=NF
+                for(i=1; i<=NF; i++) { f[tolower($i)]=NF-i }
+            }
+            FNR>1 {
+                FIELD_NUM=NF-f[DISK_COLUMN]
+                if(FIELD_NUM > 0) {
+                    VALUE=$(FIELD_NUM)
+                    print VALUE
+                } else if(f[DISK_COLUMN] == NF_HEADER-1 && NF == 1) {
+                    VALUE=$(1)
+                    print VALUE
+                }
+            }' \
+    )
+    # If value is a number follwed by letters, it is a value with units
+    # and needs to be converted. Otherwise just print value
+    if [[ "$VALUE" =~ [0-9.]+[A-z]+ ]]; then
+        echo "$VALUE"\
+        | sed -E 's/([0-9.]*)([^0-9.]*)/\1 \2/' \
+        | awk '{
+            UNIT=substr($2, 1, 1)
+            if(UNIT == "T") {
+                SCALE=2^10
+            } else if(UNIT == "G") {
+                SCALE=1
+            } else if(UNIT == "M") {
+                SCALE=2^-10
+            } else if(UNIT == "K") {
+                SCALE=2^-20
+            } else if(UNIT == "B") {
+                SCALE=2^-30
+            } else {
+                SCALE=1
+            }
+            printf "%.3f GiB", $1 * SCALE
+        }'
+    else
+        echo "$VALUE"
+    fi
+}
+
+function findBlockDevice() {
+    MOUNT_POINT=$1
+    FILESYSTEM=$(grep -E "$MOUNT_POINT\s" /proc/self/mounts \
+                | awk '{print $1}')
+    DEVICE_NAME=$(basename "$FILESYSTEM")
+    FS_IN_BLOCK=$(find -L /sys/block/ -mindepth 2 -maxdepth 2 -type d \
+                       -name "$DEVICE_NAME")
+    if [ -n "$FS_IN_BLOCK" ]; then
+        # found path to the filesystem in the block devices. get the
+        # block device as the parent dir
+        dirname "$FS_IN_BLOCK"
+    elif [ -d "/sys/block/$DEVICE_NAME" ]; then
+        # the device is itself a block device
+        echo "/sys/block/$DEVICE_NAME"
+    else
+        # couldn't find, possibly mounted by mapper.
+        # look for block device that is just the name of the symlinked
+        # original file. if not found, echo empty string (no device found)
+        BLOCK_DEVICE=$(ls -l "$FILESYSTEM" 2>/dev/null \
+                        | cut -d'>' -f2 \
+                        | xargs basename 2>/dev/null \
+                        || echo)
+        if [[ -z "$BLOCK_DEVICE" ]]; then
+            1>&2 echo "Unable to find block device for filesystem $FILESYSTEM."
+            if [[ -d /sys/block/sdb ]] && ! grep -qE "^/dev/sdb" /etc/mtab; then
+                1>&2 echo "Guessing present but unused sdb is the correct block device."
+                echo "/sys/block/sdb"
+            else           
+                1>&2 echo "Disk IO will not be monitored."
+            fi
+        fi
+    fi
+}
+
+function handle_integer_wrap() {
+    if [ $1 -ge 0 ]; then
+        echo $1
+    else
+        WRAPPED=$1
+        echo "$((WRAPPED + 2**30))"
+    fi
+}
+
+
+
+function getBlockDeviceIO() {
+    # get read and write IO rate by looking at appropriate block device
+    STAT_FILE="$1"
+    if [[ -f "$STAT_FILE" ]]; then
+        # get IO stats as comma-separated list to extract 3rd and 7th fields
+        STATS=$(sed -E 's/[[:space:]]+/,/g' $STAT_FILE | sed -E 's/^,//'\
+                | cut -d, -f3,7 | sed -E 's/,/ /g')
+        # get results of previous poll
+        read OLD_READ OLD_WRITE < $TEMP_IO
+        # save new poll results
+        read READ_SECTORS WRITE_SECTORS <<<$STATS
+        echo "$READ_SECTORS $WRITE_SECTORS" > $TEMP_IO
+        # update read and write sectors as difference since previous poll
+        READ_SECTORS=$(handle_integer_wrap $((READ_SECTORS - OLD_READ)))
+        WRITE_SECTORS=$(handle_integer_wrap $((WRITE_SECTORS - OLD_WRITE)))
+
+        # output change in read/write sectors in kiB/s
+        echo "$READ_SECTORS $WRITE_SECTORS" \
+            | awk -v T=$SLEEP_TIME -v B=$SECTOR_BYTES \
+                '{ printf "%.3f MiB/s %.3f MiB/s",  $1*B/T/1048576, $2*B/T/1048576 }'
+    else
+        echo "N/A MiB/s N/A MiB/s"
+    fi
+}
+
+
+function runtimeInfo() {
+    echo "  [$(date)]"
+    echo \* CPU usage: $(getCpuUsage)
+    echo \* Memory usage: $(getMemUnavailable)
+    echo \* Disk usage: $(getDisk Used $MONITOR_MOUNT_POINT) $(getDisk Use% $MONITOR_MOUNT_POINT)
+    echo \* Read/Write IO: $(getBlockDeviceIO "$BLOCK_DEVICE_STAT_FILE")
+}
+
+# print out header info
+echo ==================================
+echo =========== MONITORING ===========
+echo ==================================
+echo --- General Information ---
+echo \#CPU: $(nproc)
+echo Total Memory: $(getMem MemTotal)
+echo Total Disk space: $(getDisk Size "$MONITOR_MOUNT_POINT")
+echo 
+echo --- Runtime Information ---
+
+
+# make a temp file to store io information, remove it on exit
+TEMP_IO=$(mktemp "${TMPDIR:-/tmp/}$(basename $0).XXXXXXXXXXXX")
+# make a temp file to store cpu information, remove it on exit
+# remove temp files on exit
+TEMP_CPU=$(mktemp "${TMPDIR:-/tmp/}$(basename $0).XXXXXXXXXXXX")
+trap "rm -f $TEMP_IO $TEMP_CPU" EXIT
+
+
+# find the block device
+BLOCK_DEVICE=$(findBlockDevice "$MONITOR_MOUNT_POINT")
+if [[ -z "$BLOCK_DEVICE" ]] \
+        || [[ ! -f "$BLOCK_DEVICE/queue/hw_sector_size" ]]; then
+    # no block device found, can't get IO info
+    SECTOR_BYTES=0
+    BLOCK_DEVICE_STAT_FILE=""
+else
+    SECTOR_BYTES=$(cat "$BLOCK_DEVICE/queue/hw_sector_size")
+    BLOCK_DEVICE_STAT_FILE="$BLOCK_DEVICE/stat"
+fi
+
+
+# since getBlockDeviceIO looks at differences in stat file, run the
+# update so the first reported update has a sensible previous result to
+# compare to
+echo "0 0" > $TEMP_IO
+getBlockDeviceIO "$BLOCK_DEVICE_STAT_FILE" > /dev/null
+
+# same thing for getCpuUsage
+echo "0 0" > $TEMP_CPU
+getCpuUsage > /dev/null
+
+
+while true; do
+    runtimeInfo
+    sleep $SLEEP_TIME
+done

--- a/wdl/TrioBinChildLongReads.wdl
+++ b/wdl/TrioBinChildLongReads.wdl
@@ -12,55 +12,53 @@ workflow TrioBinChildLongReads {
         String mother_short_reads_bucket
 
         String child_long_reads_bucket
+        # currently the following only takes one of [pacbio-raw, nanopore-raw]
+        String long_read_platform
 
-        # these numbers will be used to request VMs on which and run all meryl jobs are run, in stages, including the configuration job
+        File vm_local_monitoring_script
+
+        # these numbers will be used to request VMs on which all meryl jobs are run, in stages
         Int meryl_operations_threads_est = 8
-        Int meryl_operations_memoryG_est = 32
 
-        Int child_read_assign_threads_est = 40
-        Int child_read_assign_memoryG_est = 256
+        Int child_read_assign_threads_est = 64
+        Int child_read_assign_memoryG_est = 64
 
         Boolean? run_with_debug = false
     }
 
-    call ParentalReadsRepartition {
+    call ParentalReadsRepartitionAndMerylConfigure {
         input:
             assembly_name = assembly_name,
             father_short_reads_bucket = father_short_reads_bucket,
             mother_short_reads_bucket = mother_short_reads_bucket,
+            meryl_operations_threads_est = meryl_operations_threads_est,
             run_with_debug = run_with_debug
     }
 
-    call MerylConfigure {
+    call PrintMerylMemory {
         input:
-            assembly_name = assembly_name,
-            father_and_mother_read_files_count_formated = ParentalReadsRepartition.father_and_mother_read_files_count_formated,
-            meryl_operations_threads_est = meryl_operations_threads_est,
-            meryl_operations_memoryG_est = meryl_operations_memoryG_est
+            meryl_memory_file = ParentalReadsRepartitionAndMerylConfigure.meryl_memory
     }
 
-    scatter (batchIdFile in MerylConfigure.batch_ids) {
+    scatter (pair in ParentalReadsRepartitionAndMerylConfigure.batch_id_and_parental_short_reads_tar) {
         call MerylCount {
             input:
                 assembly_name = assembly_name,
-                batch_id_hold_file = batchIdFile,
-                meryl_count_script = MerylConfigure.count_script,
-                meryl_count_memory = MerylConfigure.meryl_memory,
-                repartitioned_father_reads = ParentalReadsRepartition.repartitioned_father_reads,
-                repartitioned_mother_reads = ParentalReadsRepartition.repartitioned_mother_reads,
+                batch_id_hold_file = pair.left,
+                parental_reads_for_this_batch = pair.right,
+                meryl_count_script = ParentalReadsRepartitionAndMerylConfigure.count_script,
                 meryl_operations_threads_est = meryl_operations_threads_est,
-                meryl_operations_memoryG_est = meryl_operations_memoryG_est
+                meryl_memory_in_GB = PrintMerylMemory.meryl_memory_in_GB
         }
     }
 
     call MerylMergeAndSubtract {
         input:
-            meryl_merge_script = MerylConfigure.merge_script,
-            meryl_subtract_script = MerylConfigure.subtract_script,
-            meryl_count_memory = MerylConfigure.meryl_memory,
+            meryl_merge_script = ParentalReadsRepartitionAndMerylConfigure.merge_script,
+            meryl_subtract_script = ParentalReadsRepartitionAndMerylConfigure.subtract_script,
             meryl_count_batches = MerylCount.count_output,
             meryl_operations_threads_est = meryl_operations_threads_est,
-            meryl_operations_memoryG_est = meryl_operations_memoryG_est,
+            meryl_memory_in_GB = PrintMerylMemory.meryl_memory_in_GB,
             run_with_debug = run_with_debug
     }
 
@@ -68,28 +66,29 @@ workflow TrioBinChildLongReads {
         input:
             assembly_name = assembly_name,
             child_long_reads_bucket = child_long_reads_bucket,
+            long_read_platform = long_read_platform,
             meryl_subtract_father = MerylMergeAndSubtract.subtract_output_father,
             meryl_subtract_mother = MerylMergeAndSubtract.subtract_output_mother,
             meryl_stats_father = MerylMergeAndSubtract.merge_stats_father,
             meryl_stats_mother = MerylMergeAndSubtract.merge_stats_mother,
             child_read_assign_threads_est = child_read_assign_threads_est,
             child_read_assign_memoryG_est = child_read_assign_memoryG_est,
+            vm_local_monitoring_script = vm_local_monitoring_script,
             run_with_debug = run_with_debug
     }
 }
 
 ###############################################################
-# TODO: serial localization is done with Cromwell 45, slowing down the pipeline signnificantly.
-#       Try and see if Cromwell 47 helps.
-###############################################################
 # repartition the parental short reads, IO bound
-task ParentalReadsRepartition {
+task ParentalReadsRepartitionAndMerylConfigure {
     input{
 
         String assembly_name
 
         String father_short_reads_bucket
         String mother_short_reads_bucket
+
+        Int meryl_operations_threads_est
 
         Boolean run_with_debug = false
 
@@ -107,9 +106,9 @@ task ParentalReadsRepartition {
         a=$(gsutil ls "${father_path}/"*.fastq.gz | wc -l)
         b=$(gsutil ls "${mother_path}/"*.fastq.gz | wc -l)
         if [[ $a == 0 ]]; then
-          echo "no reads in ~{father_short_reads_bucket}"
+          echo "no reads in ~{father_short_reads_bucket}" && exit 1
         elif [[ $b == 0 ]]; then
-          echo "no reads in ~{mother_short_reads_bucket}"
+          echo "no reads in ~{mother_short_reads_bucket}" && exit 1
         fi
         echo "==================================="
         echo "BEGIN LOCALIZING PARENTAL READS"
@@ -122,7 +121,11 @@ task ParentalReadsRepartition {
         echo "==================================="
 
         ##########
-        # re-partition parental reads and stop there
+        # re-partition parental reads and
+        # very importantly, we don't stop at that, we stop after parental kmer stats configure
+        # (i.e. meryl-count, -merge, and -subtract) because
+        # the custom docker allows us to output a batch-specific tar.gz of parental read files
+        # but we don't use the configuration scripts in later stages
         echo "==================================="
         date -u
         canu \
@@ -130,138 +133,35 @@ task ParentalReadsRepartition {
             -p ~{assembly_name} \
             -d /cromwell_root/workdir/ \
             genomeSize=3.1G \
-            stopAfter=parental-reads-repartition \
+            stopAfter=parent-kmer-stat-conf \
             -haplotypeFather /cromwell_root/father/*.fastq.gz \
             -haplotypeMother /cromwell_root/mother/*.fastq.gz \
             ~{extra_args}
         date -u
         tree workdir # helps debugging, in case something went wrong
-        echo "==================================="
-        ##########
-
-        # save logs and scripts
-        tar -czf canu-logs.tar.gz workdir/canu-logs
-        tar -czf canu-scripts.tar.gz workdir/canu-scripts
-
-        # pack up re-partitioned reads
-        tar -czf reads-Father.tar.gz workdir/haplotype/0-kmers/reads-Father &
-        tar -czf reads-Mother.tar.gz workdir/haplotype/0-kmers/reads-Mother &
+        # tar the repartitioned reads according to batches
+        cd workdir/haplotype/0-kmers/
+        for dict in *.dict; do
+            new_name=$(echo $dict | sed 's/dict//')
+            cat $dict | tar -czf $new_name"batch.tar.gz" -T - &
+        done
         wait
-        du -sh father mother reads-Father.tar.gz reads-Mother.tar.gz
-
-        # a trick to be used later
-        a=$(ls workdir/haplotype/0-kmers/reads-Father/*.fasta.gz | wc -l | awk '{print $1}')
-        b=$(ls workdir/haplotype/0-kmers/reads-Mother/*.fasta.gz | wc -l | awk '{print $1}')
-        echo $a"_"$b > parental_read_files_count.txt
-    >>>
-
-    output {
-
-        File logs = "canu-logs.tar.gz"
-        File scripts = "canu-scripts.tar.gz"
-
-        File repartitioned_father_reads = "reads-Father.tar.gz"
-        File repartitioned_mother_reads = "reads-Mother.tar.gz"
-
-        File father_and_mother_read_files_count_formated = "parental_read_files_count.txt"
-    }
-
-    #########################
-    RuntimeAttr default_attr = object {
-        cpu_cores:          4,
-        mem_gb:             8,
-        disk_gb:            600,
-        boot_disk_gb:       10,
-        preemptible_tries:  1,
-        max_retries:        0,
-        docker:             "quay.io/broad-long-read-pipelines/canu:v1.9_wdl"
-    }
-    RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
-    runtime {
-        cpu:                    select_first([runtime_attr.cpu_cores,         default_attr.cpu_cores])
-        memory:                 select_first([runtime_attr.mem_gb,            default_attr.mem_gb]) + " GiB"
-        disks: "local-disk " +  select_first([runtime_attr.disk_gb,           default_attr.disk_gb]) + " LOCAL" # LOCAL because this task is mostly IO operation
-        bootDiskSizeGb:         select_first([runtime_attr.boot_disk_gb,      default_attr.boot_disk_gb])
-        preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
-        maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])
-        docker:                 select_first([runtime_attr.docker,            default_attr.docker])
-    }
-}
-
-# configures the meryl-count, -merge, and -subtract shell scripts
-# a good estimate on the machine configuration is critial for good performance on count/merge/subtract operations
-task MerylConfigure {
-    input{
-
-        String assembly_name
-
-        # this is a specially coded string of format "a_b", where
-        # a is the number of re-partitioned file count for father, and b is for mother
-        # we are going to do a little trick below
-        File father_and_mother_read_files_count_formated
-
-        Int meryl_operations_threads_est
-        Int meryl_operations_memoryG_est
-
-        RuntimeAttr? runtime_attr_override
-    }
-
-    command <<<
-        set -euo pipefail
-
-        mkdir -p workdir/canu-logs workdir/canu-scripts
-        mkdir -p workdir/haplotype/0-kmers/reads-Father workdir/haplotype/0-kmers/reads-Mother
-
-        # here we do a trick, because we know that the configuration subroutine only takes a look at how many fasta files there are
-        # instead of how large they are (they are assumed to be of fixed size--the reason for repartition)
-        # we are simply going to just touch-create those files, to "fool" the configuration subroutine
-        father_count=$(cat ~{father_and_mother_read_files_count_formated} | awk -F '_' '{print $1}')
-        mother_count=$(cat ~{father_and_mother_read_files_count_formated} | awk -F '_' '{print $2}')
-        echo "Father read files count: $father_count"
-        echo "Mother read files count: $mother_count"
-        for i in `seq $father_count`; do
-            if [[ $i -le 999 ]]; then
-                padded=$(printf %03d $i) # necessary, as the canu code format things in that order
-            else
-                padded=$(printf %04d $i)
-            fi
-            touch workdir/haplotype/0-kmers/reads-Father/reads-Father-$padded.fasta.gz;
-        done
-        for i in `seq $mother_count`; do
-            if [[ $i -le 999 ]]; then
-                padded=$(printf %03d $i) # necessary, as the canu code format things in that order
-            else
-                padded=$(printf %04d $i)
-            fi
-            touch workdir/haplotype/0-kmers/reads-Mother/reads-Mother-$padded.fasta.gz;
-        done
-        # this avoids re-doing the repartition work exactly because
-        # accompanying the repartitioned reads, there are these "*.success" files
-        # fooling canu again
-        touch workdir/haplotype/0-kmers/reads-Father/reads-Father.success
-        touch workdir/haplotype/0-kmers/reads-Mother/reads-Mother.success
-
-        ##########
-        echo "==================================="
-        date -u
-        canu \
-            -haplotype \
-            -p ~{assembly_name} \
-            -d /cromwell_root/workdir/ \
-            genomeSize=3.1G \
-            beginConfigAt=meryl \
-            stopAfter=meryl-configure \
-            -haplotypeFather /cromwell_root/workdir/haplotype/0-kmers/reads-Father/*.fasta.gz \
-            -haplotypeMother /cromwell_root/workdir/haplotype/0-kmers/reads-Mother/*.fasta.gz \
-            -debug # explicitly turn on debugging here because we want to see more of the configuration process, for easier debugging if something goes wrong
-        date -u
+        cd -
         echo "==================================="
         ##########
 
-        # save result
-        cp workdir/haplotype/0-kmers/*.sh .
-        cp workdir/haplotype/0-kmers/meryl-count.memory .
+        # move configured shell scripts up for delocalization, then sed replace the thread configuration
+        # recall that memory is set purely based on file count
+        mv workdir/haplotype/0-kmers/meryl-count.memory .
+        mv workdir/haplotype/0-kmers/*.sh .
+        th_cnt=~{meryl_operations_threads_est}
+        for script in *.sh; do
+            sed -i -E "s/threads=[0-9]+/threads=$th_cnt/g" $script;
+        done
 
+        # move parental reads up for delocalization
+        mv workdir/haplotype/0-kmers/*.dict .
+        mv workdir/haplotype/0-kmers/*.batch.tar.gz .
         # grep and sort, then generate an array of flat files that just hold the "$hap-bathid"
         for batch_id in `grep -Eo "output=\"(Father|Mother)-[0-9]+\"" meryl-count.sh | awk -F '=' '{print $2}' | sed 's/"//g'`; do
             echo $batch_id > "$batch_id.txt"
@@ -279,6 +179,8 @@ task MerylConfigure {
         File scripts = "canu-scripts.tar.gz"
 
         Array[File] batch_ids = glob("*.txt")
+        Array[File] repartitioned_parental_reads_per_batch = glob("*.batch.tar.gz")
+        Array[Pair[String, File]] batch_id_and_parental_short_reads_tar = zip(batch_ids, repartitioned_parental_reads_per_batch)
 
         File meryl_memory = "meryl-count.memory"
         File count_script = "meryl-count.sh"
@@ -288,23 +190,43 @@ task MerylConfigure {
 
     #########################
     RuntimeAttr default_attr = object {
-        cpu_cores:          meryl_operations_threads_est + 2,
-        mem_gb:             meryl_operations_memoryG_est + 2,
-        disk_gb:            50, # such a small size because we don't actuall have any large files to deal with in this stage
+        cpu_cores:          4,
+        mem_gb:             8,
+        disk_gb:            600,
         boot_disk_gb:       10,
-        preemptible_tries:  1,
+        preemptible_tries:  0, # explicitly turn this off as we don't save that much for the disk, and pre-emption kills us
         max_retries:        0,
-        docker:             "quay.io/broad-long-read-pipelines/canu:v1.9_wdl"
+        docker:             "quay.io/broad-long-read-pipelines/canu:v1.9_wdl_patch"
     }
     RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
     runtime {
         cpu:                    select_first([runtime_attr.cpu_cores,         default_attr.cpu_cores])
         memory:                 select_first([runtime_attr.mem_gb,            default_attr.mem_gb]) + " GiB"
-        disks: "local-disk " +  select_first([runtime_attr.disk_gb,           default_attr.disk_gb]) + " HDD"
+        disks: "local-disk " +  select_first([runtime_attr.disk_gb,           default_attr.disk_gb]) + " LOCAL" # LOCAL because this task is mostly IO operation
         bootDiskSizeGb:         select_first([runtime_attr.boot_disk_gb,      default_attr.boot_disk_gb])
         preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
         maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])
         docker:                 select_first([runtime_attr.docker,            default_attr.docker])
+    }
+}
+
+task PrintMerylMemory {
+    input {
+        File meryl_memory_file
+    }
+
+    command <<<
+        cat ~{meryl_memory_file}
+    >>>
+
+    output {
+        Int meryl_memory_in_GB = read_int(stdout())
+    }
+
+    runtime {
+        cpu: 1
+        memory: "1 GiB"
+        docker: "ubuntu:18.04"
     }
 }
 
@@ -315,20 +237,19 @@ task MerylCount {
         String assembly_name
 
         File batch_id_hold_file
-        File meryl_count_script
-        File meryl_count_memory
+        File parental_reads_for_this_batch
 
-        # tar.gz files, to avoid the super slow localization process
-        File repartitioned_father_reads
-        File repartitioned_mother_reads
+        File meryl_count_script
 
         Int meryl_operations_threads_est
-        Int meryl_operations_memoryG_est
+        Int meryl_memory_in_GB
 
         RuntimeAttr? runtime_attr_override
     }
 
     String postfix = basename(batch_id_hold_file, ".txt")
+
+    Int half_meryl_memory = ceil(meryl_memory_in_GB/2)
 
     command <<<
         set -euo pipefail
@@ -336,38 +257,45 @@ task MerylCount {
         mkdir -p workdir/canu-logs workdir/canu-scripts
         mkdir -p workdir/haplotype/0-kmers/reads-Father workdir/haplotype/0-kmers/reads-Mother
 
-        cp ~{meryl_count_script} ~{meryl_count_memory} workdir/haplotype/0-kmers/
+        cp ~{meryl_count_script} workdir/haplotype/0-kmers/
+        echo ~{meryl_memory_in_GB} > workdir/haplotype/0-kmers/meryl-count.memory
 
-        # move reads to the correct location
         echo "==================================="
         echo "BEGIN UNPACKING REPARTITIONED PARENTAL READS TO THE DESIRED LOCATIONS"
         date -u
-        tar xzf ~{repartitioned_father_reads} -C /cromwell_root/ &
-        tar xzf ~{repartitioned_mother_reads} -C /cromwell_root/ &
-        wait
+        df -h
+        tar xzfv ~{parental_reads_for_this_batch} -C workdir/haplotype/0-kmers/
+        rm ~{parental_reads_for_this_batch} # save some disk space
+        df -h
         date -u
+        tree workdir
         echo "DONE UNPACKING REPARTITIONED PARENTAL READS TO THE DESIRED LOCATIONS"
         echo "==================================="
 
         ##########
         # run the script
+        # this is essentially the command by canu::Execution::submitOrRunParallelJob
         echo "==================================="
+        echo "BEGIN KMER COUNTING"
         date -u
         n=$(cat ~{batch_id_hold_file} | awk -F '-' '{print $2}' | sed 's/^0*//')
         log_name="meryl-count."~{postfix}".out"
         echo "Dealing with batch: ${n}, with log name: ${log_name}"
-        cd workdir/haplotype/0-kmers/ && chmod +x meryl-count.sh # && sed -i '2iset -eu' meryl-count.sh # turn off this usual safeguard because the shell script has some non-best practice behavior
-        ./meryl-count.sh ${n} > ${log_name} 2>&1 || cat ${log_name} # this is essentially the command by canu::Execution::submitOrRunParallelJob
-        cd -
+        cd workdir/haplotype/0-kmers/ && chmod +x meryl-count.sh
+        ./meryl-count.sh ${n} > ${log_name} 2>&1 || cat ${log_name}
+        tail -n 5 ${log_name}
         date -u
+        tar -czf reads-~{postfix}.meryl.tar.gz reads-~{postfix}.meryl
+        du -sh reads-~{postfix}.meryl.tar.gz
+        cd -
+        df -h
+        date -u
+        echo "DONE  KMER COUNTING"
         echo "==================================="
         ##########
 
-        # rm to make space for tar
-        rm -rf ~{repartitioned_father_reads} \
-               ~{repartitioned_mother_reads}
-        tar -czf reads-~{postfix}.meryl.tar.gz workdir/haplotype/0-kmers/reads-~{postfix}.meryl
-        du -sh reads-~{postfix}.meryl.tar.gz
+        mv workdir/haplotype/0-kmers/reads-~{postfix}.meryl.tar.gz .
+        mv workdir/haplotype/0-kmers/meryl-count.~{postfix}.out .
 
         # save logs and scripts
         tar -czf canu-logs.tar.gz workdir/canu-logs
@@ -379,26 +307,26 @@ task MerylCount {
         File logs = "canu-logs.tar.gz"
         File scripts = "canu-scripts.tar.gz"
 
-        File count_log = "workdir/haplotype/0-kmers/meryl-count.${postfix}.out"
+        File count_log = "meryl-count.${postfix}.out"
 
         File count_output = "reads-~{postfix}.meryl.tar.gz"
     }
 
     #########################
     RuntimeAttr default_attr = object {
-        cpu_cores:          meryl_operations_threads_est + 2,
-        mem_gb:             meryl_operations_memoryG_est + 2,
-        disk_gb:            500,
+        cpu_cores:          meryl_operations_threads_est / 2,
+        mem_gb:             if (16 < half_meryl_memory) then half_meryl_memory else 16,
+        disk_gb:            20,
         boot_disk_gb:       10,
         preemptible_tries:  1,
         max_retries:        0,
-        docker:             "quay.io/broad-long-read-pipelines/canu:v1.9_wdl"
+        docker:             "quay.io/broad-long-read-pipelines/canu:v1.9_wdl_patch"
     }
     RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
     runtime {
         cpu:                    select_first([runtime_attr.cpu_cores,         default_attr.cpu_cores])
         memory:                 select_first([runtime_attr.mem_gb,            default_attr.mem_gb]) + " GiB"
-        disks: "local-disk " +  select_first([runtime_attr.disk_gb,           default_attr.disk_gb]) + " LOCAL"
+        disks: "local-disk " +  select_first([runtime_attr.disk_gb,           default_attr.disk_gb]) + " HDD"
         bootDiskSizeGb:         select_first([runtime_attr.boot_disk_gb,      default_attr.boot_disk_gb])
         preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
         maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])
@@ -413,12 +341,11 @@ task MerylMergeAndSubtract {
 
         File meryl_merge_script
         File meryl_subtract_script
-        File meryl_count_memory
 
         Array[File] meryl_count_batches
 
         Int meryl_operations_threads_est
-        Int meryl_operations_memoryG_est
+        Int meryl_memory_in_GB
 
         Boolean run_with_debug = false
 
@@ -432,14 +359,17 @@ task MerylMergeAndSubtract {
         date -u
         echo "BEGIN UNPACKING SCATTERED meryl-count RESULTS"
         mkdir -p workdir/canu-logs workdir/canu-scripts workdir/haplotype/0-kmers/
-        cp ~{meryl_merge_script} ~{meryl_subtract_script} ~{meryl_count_memory} workdir/haplotype/0-kmers/
+        cp ~{meryl_merge_script} \
+           ~{meryl_subtract_script} \
+           workdir/haplotype/0-kmers/
+        echo ~{meryl_memory_in_GB} > workdir/haplotype/0-kmers/meryl-count.memory
         for zipped_count in `ls ~{sep=' ' meryl_count_batches}`; do
-            tar xzf ${zipped_count} -C workdir/haplotype/0-kmers/ &
+            out_log_prefix=$(basename ${zipped_count})
+            (tar xzfv ${zipped_count} -C workdir/haplotype/0-kmers/ > ${out_log_prefix}".unpacking.log" && rm -rf ${zipped_count}) &
         done
         wait
-        for zipped_count in `ls ~{sep=' ' meryl_count_batches}`; do
-            rm -rf ${zipped_count}
-        done
+        echo "disk use after unpacking:"
+        df -h
         date -u
         echo "DONE  UNPACKING SCATTERED meryl-count RESULTS"
         echo "==================================="
@@ -450,8 +380,7 @@ task MerylMergeAndSubtract {
         date -u
         cd workdir/haplotype/0-kmers/
         chmod +x meryl-merge.sh && chmod +x meryl-subtract.sh
-        # sed -i '2iset -eu' meryl-merge.sh && sed -i '2iset -eu' meryl-subtract.sh && \ # turn off this usual safeguard because the shell script has some non-best practice behavior
-        mv workdir/haplotype/0-kmers/reads-*.meryl . && rm -rf workdir
+        # merge
         ./meryl-merge.sh 1 > meryl-merge.000001.out 2>&1 &
         ./meryl-merge.sh 2 > meryl-merge.000002.out 2>&1 &
         wait
@@ -459,7 +388,14 @@ task MerylMergeAndSubtract {
             cat meryl-merge.000001.out
             cat meryl-merge.000002.out
         fi
+        echo "disk use after merge operation:"
+        df -h
+        du -sh *
+        rm -rf reads-Father-*.meryl.tar.gz # delete these count files after merge
+        rm -rf reads-Mother-*.meryl.tar.gz # delete these count files after merge
         date -u
+        echo "-----------------------------------"
+        # subtract
         ./meryl-subtract.sh 1 > meryl-subtract.000001.out 2>&1 &
         ./meryl-subtract.sh 2 > meryl-subtract.000002.out 2>&1 &
         wait
@@ -467,11 +403,19 @@ task MerylMergeAndSubtract {
             cat meryl-subtract.000001.out
             cat meryl-subtract.000002.out
         fi
-        cd -
+        echo "disk use after subtract operation:"
+        df -h
+        du -sh *
         date -u
-        du -sh workdir
+        cd -
         echo "==================================="
         ##########
+
+        mv workdir/haplotype/0-kmers/*.out .
+        mv workdir/haplotype/0-kmers/reads-*.statistics .
+
+        mv workdir/haplotype/0-kmers/haplotype-Father.meryl .
+        mv workdir/haplotype/0-kmers/haplotype-Mother.meryl .
 
         # save logs and scripts
         tar -czf canu-logs.tar.gz workdir/canu-logs
@@ -481,27 +425,28 @@ task MerylMergeAndSubtract {
     output {
         File logs = "canu-logs.tar.gz"
         File scripts = "canu-scripts.tar.gz"
+        Array [File] unpacking_logs = glob("*.unpacking.log")
 
-        Array[File] merge_log = glob("workdir/haplotype/0-kmers/meryl-merge.*.out")
-        File merge_stats_father = "workdir/haplotype/0-kmers/reads-Father.statistics"
-        File merge_stats_mother = "workdir/haplotype/0-kmers/reads-Mother.statistics"
+        Array[File] merge_log = glob("meryl-merge.*.out")
+        File merge_stats_father = "reads-Father.statistics"
+        File merge_stats_mother = "reads-Mother.statistics"
         # Array[File] merge_output_mother = glob("workdir/haplotype/0-kmers/reads-Mother.meryl/*") # we take these out for now because
         # Array[File] merge_output_father = glob("workdir/haplotype/0-kmers/reads-Father.meryl/*") # these are usually deleted in the canu pipeline
 
-        Array[File] subtract_log = glob("workdir/haplotype/0-kmers/meryl-subtract.*.out")
-        Array[File] subtract_output_father = glob("workdir/haplotype/0-kmers/haplotype-Father.meryl/*")
-        Array[File] subtract_output_mother = glob("workdir/haplotype/0-kmers/haplotype-Mother.meryl/*")
+        Array[File] subtract_log = glob("meryl-subtract.*.out")
+        Array[File] subtract_output_father = glob("haplotype-Father.meryl/*")
+        Array[File] subtract_output_mother = glob("haplotype-Mother.meryl/*")
     }
 
     #########################
     RuntimeAttr default_attr = object {
         cpu_cores:          2 * meryl_operations_threads_est + 2,
-        mem_gb:             2 * meryl_operations_memoryG_est + 2,# choosing this specification so that two parallel jobs can be executed at the same time
-        disk_gb:            1000,
+        mem_gb:             2 * meryl_memory_in_GB + 2, # choosing this specification so that two parallel jobs can be executed at the same time
+        disk_gb:            1500, # we strongly recommend you NOT lower this number, as we've seen it typically gets closer to 1.2T peak usage, and local SSD's increase by unit of 375GB
         boot_disk_gb:       10,
         preemptible_tries:  0, # explicitly turn off as this takes a long time
         max_retries:        0,
-        docker:             "quay.io/broad-long-read-pipelines/canu:v1.9_wdl"
+        docker:             "quay.io/broad-long-read-pipelines/canu:v1.9_wdl_patch"
     }
     RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
     runtime {
@@ -522,6 +467,8 @@ task AssignChildLongReads {
         String assembly_name
 
         String child_long_reads_bucket
+        # currently the following only takes one of [pacbio-raw, nanopore-raw]
+        String long_read_platform
 
         Array[File] meryl_subtract_father
         Array[File] meryl_subtract_mother
@@ -532,12 +479,15 @@ task AssignChildLongReads {
         Int child_read_assign_threads_est
         Int child_read_assign_memoryG_est
 
+        File vm_local_monitoring_script
+
         Boolean run_with_debug = false
 
         RuntimeAttr? runtime_attr_override
     }
 
     String extra_args = if (run_with_debug) then "-debug" else " "
+    String resource_script_name = basename(vm_local_monitoring_script)
 
     command <<<
         set -euo pipefail
@@ -548,7 +498,7 @@ task AssignChildLongReads {
         child_path=$(echo ~{child_long_reads_bucket} | sed 's:/*$::')
         a=$(gsutil ls "${child_path}/"*.fastq.gz | wc -l)
         if [[ $a == 0 ]]; then
-          echo "no reads in ~{child_long_reads_bucket}"
+          echo "no reads in ~{child_long_reads_bucket}" && exit 1
         fi
         echo "==================================="
         echo "BEGIN LOCALIZING CHILD LONG READS"
@@ -584,6 +534,9 @@ task AssignChildLongReads {
         machine_mem=`echo $(($(getconf _PHYS_PAGES) * $(getconf PAGE_SIZE) / (1024 * 1024 * 1024)))`
         hap_mem=$(($machine_mem - 2))
         echo "Limiting hap memory to: ${hap_mem} G"
+        export MONITOR_MOUNT_POINT="/cromwell_root"
+        bash ~{vm_local_monitoring_script} &> resources.log &
+        job_id=$(ps -aux | grep -F ~{resource_script_name} | head -1 | awk '{print $2}')
         canu \
             -haplotype \
             -p ~{assembly_name} \
@@ -593,13 +546,19 @@ task AssignChildLongReads {
             stopAfter=haplotype \
             hapMemory=${hap_mem} \
             -hapNames "Father Mother" \
-            -pacbio-raw /cromwell_root/child/*.fastq.gz \
+            -~{long_read_platform} /cromwell_root/child/*.fastq.gz \
             ~{extra_args} ||
             cat workdir/haplotype/*.out
+        kill $job_id || true
         du -sh workdir/haplotype/*
         date -u
         echo "==================================="
         ##########
+
+        mv workdir/haplotype/haplotype.log .
+        mv workdir/haplotype/splitHaplotype.000001.out .
+        mv workdir/haplotype/splitHaplotype.sh .
+        mv workdir/haplotype/haplotype-*.fasta.gz .
 
         # save logs and scripts
         tar -czf canu-logs.tar.gz workdir/canu-logs
@@ -610,24 +569,26 @@ task AssignChildLongReads {
         File logs = "canu-logs.tar.gz"
         File scripts = "canu-scripts.tar.gz"
 
-        File assignment_log = "workdir/haplotype/haplotype.log"
-        File assignment_job_log = "workdir/haplotype/splitHaplotype.000001.out"
-        File assignment_script = "workdir/haplotype/splitHaplotype.sh"
+        File resource_monitoring_log = "resources.log"
 
-        File reads_assigned_to_father = "workdir/haplotype/haplotype-Father.fasta.gz"
-        File reads_assigned_to_mother = "workdir/haplotype/haplotype-Mother.fasta.gz"
-        File unassigned_reads = "workdir/haplotype/haplotype-unknown.fasta.gz"
+        File assignment_log = "haplotype.log"
+        File assignment_job_log = "splitHaplotype.000001.out"
+        File assignment_script = "splitHaplotype.sh"
+
+        File reads_assigned_to_father = "haplotype-Father.fasta.gz"
+        File reads_assigned_to_mother = "haplotype-Mother.fasta.gz"
+        File unassigned_reads = "haplotype-unknown.fasta.gz"
     }
 
     #########################
     RuntimeAttr default_attr = object {
         cpu_cores:          child_read_assign_threads_est,
         mem_gb:             child_read_assign_memoryG_est,
-        disk_gb:            500,
+        disk_gb:            300,
         boot_disk_gb:       10,
         preemptible_tries:  1,
         max_retries:        0,
-        docker:             "quay.io/broad-long-read-pipelines/canu:v1.9_wdl"
+        docker:             "quay.io/broad-long-read-pipelines/canu:v1.9_wdl_patch"
     }
     RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
     runtime {


### PR DESCRIPTION
  * update to new docker (github SHuang-Broad/canu-wdl:v1.9_wdl_patch) with
      1) two official bug-fixing patches on kmer stats
      2) smaller meryl count batch sizes (hence higher batch count)
      3) dynamically-generated batch defining dict file that
         allows repartitioned parental reads zipped together and localized/delocalized per meryl-count batch
  * new architecture--reflecting the changes in docker--in the parental read repartition and configuration step
  * tune resources due to smaller batch sizes
  * requires a new shell script that monitors the resource usage locally (shell script added in scripts dir)
    this together with the two canu patches help lowered memory requirement
  * accepts either pacbio-raw or nanopore-raw for child long read

The overall runtime is reduced by ~ 3 hours.
Note: this puts the parental reads re-partition task a more serious offender, taking 4.5 hours as before, i.e. 50% of the wall clock time.

https://cromwell-v47.dsde-methods.broadinstitute.org/api/workflows/v1/944e240a-f9d9-4fd6-8e2b-0d28a28e9d17/timing
https://cromwell-v47.dsde-methods.broadinstitute.org/api/workflows/v1/b409e62a-86a9-409a-b447-39a386b55aa3/timing