### PR TITLE
less free-style git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,6 @@
 scratch
-cromwell-workflow-logs
-pb_eap
-bin
-results
-reports
-*.swp
-*.jar
 .DS_Store
-reports/.DS_Store
 .idea
 .Rproj.user
 .RData
 .bak
-*.png
-*.pdf


### PR DESCRIPTION
This forces us to be more cautious, as sometimes files (e.g. jars) will be mentioned in files not ignored and local test builds will pass, but becomes a problem later.