### PR TITLE
Suffix job workflow aliases with a timestamp

### DIFF
--- a/scripts/wdl/batch_submit_jobs.sh
+++ b/scripts/wdl/batch_submit_jobs.sh
@@ -147,7 +147,11 @@ export -f keep_submitting_and_alias
 
 for input_json in `cat ${INPUT_JSON_LIST}`; do
     filename=$(basename -- "${input_json}")
-    nick="${filename%.*}"
+    timestamp=$(date '+%Y%m%d%H%M%S')
+    nick="${filename%.*}.${timestamp}"
+
+    echo "${nick}"
+
     keep_submitting_and_alias \
         "${nick}" \
         "${WORKFLOW_WDL}" \

--- a/scripts/wdl/batch_submit_jobs.sh
+++ b/scripts/wdl/batch_submit_jobs.sh
@@ -150,8 +150,6 @@ for input_json in `cat ${INPUT_JSON_LIST}`; do
     timestamp=$(date '+%Y%m%d%H%M%S')
     nick="${filename%.*}.${timestamp}"
 
-    echo "${nick}"
-
     keep_submitting_and_alias \
         "${nick}" \
         "${WORKFLOW_WDL}" \


### PR DESCRIPTION
When resubmitting a failed job, the new job's alias collides with the old job's alias.  This pull request adds a timestamp to each workflow alias to fix this issue.