### PR TITLE
Updated the CCS task to fix call caching.

### DIFF
--- a/wdl/tasks/PBUtils.wdl
+++ b/wdl/tasks/PBUtils.wdl
@@ -105,13 +105,19 @@ task CCS {
     command <<<
         set -euxo pipefail
 
+        # Move the file from the UUID share to the current folder.
+        # This will remove the UUID from the file path and allow call caching to work.
+        infile=$( basename ~{subreads} )
+        mv ~{subreads} $infile
+
+        # Run CCS:
         ccs --min-passes ~{min_passes} \
             --min-snr ~{min_snr} \
             --min-length ~{min_length} \
             --max-length ~{max_length} \
             --min-rq ~{min_rq} \
             --num-threads ~{cpus} \
-            ~{subreads} ccs_unmapped.bam
+            $infile ccs_unmapped.bam
     >>>
 
     output {


### PR DESCRIPTION
Added a pre-ccs step to the CCS task to move the input files to the
current working directory.  This will cause the PG headerline in the
resulting bam file to include only the file name and not the UUID folder
containing the input file (thereby allowing call caching to work).