### PR TITLE
Higher resources for SVIM

### DIFF
--- a/wdl/tasks/CallSVs.wdl
+++ b/wdl/tasks/CallSVs.wdl
@@ -217,7 +217,7 @@ task SVIM {
         prefix: "prefix for output"
     }
 
-    Int disk_size = ceil(size(bam, "GB")) + 10
+    Int disk_size = 2 * ceil(size([bam, bai, ref_fasta, ref_fasta_fai], "GB"))
 
     command <<<
         set -euo pipefail
@@ -236,7 +236,7 @@ task SVIM {
     #########################
     RuntimeAttr default_attr = object {
         cpu_cores:          2,
-        mem_gb:             8,
+        mem_gb:             10,
         disk_gb:            disk_size,
         boot_disk_gb:       10,
         preemptible_tries:  1,


### PR DESCRIPTION
Otherwise the worker seem to be stuck at the localization for a while, then die.

A phenomenon we've seen before with older version of Cromwell but never pinned down exactly why.

Now with Cromwell 51, I'm pretty sure disk space is the cause based on multiple samples and runs.