### PR TITLE
Updated Monitoring Docker

### DIFF
--- a/resources/workflow_options/bqMonitorImage.json
+++ b/resources/workflow_options/bqMonitorImage.json
@@ -1,5 +1,5 @@
 {
-  "monitoring_image": "bshifaw/cromwell-task-monitor-bq:latest",
+  "monitoring_image": "us.gcr.io/broad-dsde-methods/cromwell-task-monitor-bq:latest",
   "final_workflow_log_dir": "gs://broad-methods-cromwell-exec-bucket-v47/cromwell_call_logs/",
   "read_from_cache": false,
   "write_to_cache": false

--- a/scripts/monitor/get_metadata_and_runtime_metrics.md
+++ b/scripts/monitor/get_metadata_and_runtime_metrics.md
@@ -21,7 +21,7 @@ Much of these two functionalities have been implemented in [this repo](https://g
 
 Users are expected to run an automated monitoring image along side their job when it is launched using cromshell.
 
-  1. Before running the workflow, specify `monitoring_image` in the workflow options json accompanying the submission (see [doc](https://cromwell.readthedocs.io/en/stable/wf_options/Google/)). An image known to be working is `bshifaw/cromwell-task-monitor-bq:latest` (this should be moved to gcr for reliability soon). 
+  1. Before running the workflow, specify `monitoring_image` in the workflow options json accompanying the submission (see [doc](https://cromwell.readthedocs.io/en/stable/wf_options/Google/)). An image known to be working is `us.gcr.io/broad-dsde-methods/cromwell-task-monitor-bq:latest` (this should be moved to gcr for reliability soon). 
 
   2. Launch the job via cromshell as you normally would
     


### PR DESCRIPTION
The monitoring docker was previously set to personal draft image in Docker hub, this is changed to an image in GCR under the methods repository. 

fixes #165