### PR TITLE
Disable GPU tests for now

### DIFF
--- a/test/test_json/all_disabled_tests.txt
+++ b/test/test_json/all_disabled_tests.txt
@@ -1,2 +1,5 @@
 test/test_json/DownloadFromSRA.test.json
 test/test_json/NanopolishRunner.test.json
+test/test_json/MedakaRunner.test.json
+test/test_json/RaconRunner.test.json
+test/test_json/GuppyRunner.test.json


### PR DESCRIPTION
There's a problem with how the Nvidia driver is being downloaded and installed.  Disable the tests for now while we confer with other teams for help.