### PR TITLE
Bug fixes for automatic population and updates to Terra tables.

### DIFF
--- a/terra/scripts/automate_pacbio_workspace.py
+++ b/terra/scripts/automate_pacbio_workspace.py
@@ -22,6 +22,7 @@ def main():
     parser.add_argument('-w', '--workspace', required=True, type=str, help="Terra workspace")
     parser.add_argument('-m', '--min-date', default='2021-03-01T00:00:00', type=str, help="Lower date cutoff")
     parser.add_argument('-r', '--run', action='store_true', help="Turn off the default dry-run mode")
+    parser.add_argument('-v', '--verbose', action='store_true', help="Turn on some additional log outputs")
     parser.add_argument('-s', '--sample_ids', type=str, nargs='*', help='Additional samples to process')
     args = parser.parse_args()
 
@@ -65,7 +66,8 @@ def main():
 
             if flowcell_date > min_date or sample_id in samples_to_process:
                 if sample_id in processed_samples and sample_id not in samples_to_process:
-                    print(f'sample_id={tbl["entity:sample_id"][i]} bio_sample={tbl["bio_sample"][i]} well_sample={tbl["well_sample"][i]} experiment_type={tbl["experiment_type"][i]} submission_id=done')
+                    if args.verbose:
+                        print(f'sample_id={tbl["entity:sample_id"][i]} bio_sample={tbl["bio_sample"][i]} well_sample={tbl["well_sample"][i]} experiment_type={tbl["experiment_type"][i]} submission_id=done')
                 else:
                     submission_id = "dry-run"
                     if args.run:

--- a/terra/scripts/update_nanopore_tables.py
+++ b/terra/scripts/update_nanopore_tables.py
@@ -179,7 +179,7 @@ def update_sample_set_table(namespace, workspace, joined_tbl):
 
     if ss_old is not None:
         ss = pd.merge(ss_old, ss, how='outer', sort=True)
-    ss = ss.replace('nan', '', regex=True)
+    ss = ss.replace('^nan$', '', regex=True)
 
     # create new membership set
     ms = joined_tbl.filter(['sample_name', 'entity:sample_id'], axis=1).drop_duplicates()

--- a/terra/scripts/update_nanopore_tables.py
+++ b/terra/scripts/update_nanopore_tables.py
@@ -66,6 +66,8 @@ def load_summaries(gcs_buckets, project):
                         t[k] = v
 
                 t['Files'] = {
+                    'fast5_pass_dir': gcs_bucket + "/" + os.path.dirname(blob.name) + "/fast5_pass",
+                    'fastq_pass_dir': gcs_bucket + "/" + os.path.dirname(blob.name) + "/fastq_pass",
                     'final_summary.txt': gcs_bucket + "/" + blob.name,
                     'sequencing_summary.txt': 'missing'
                 }
@@ -87,13 +89,15 @@ def load_summaries(gcs_buckets, project):
 def load_new_sample_table(buckets, project):
     ts = load_summaries(buckets, project)
 
-    tbl_header = ["final_summary_file", "sequencing_summary_file", "protocol_group_id", "instrument", "position", "flow_cell_id", "sample_name", "basecalling_enabled", "started", "acquisition_stopped", "processing_stopped", "fast5_files_in_fallback", "fast5_files_in_final_dest", "fastq_files_in_fallback", "fastq_files_in_final_dest"]
+    tbl_header = ["final_summary_file", "sequencing_summary_file", "fast5_pass_dir", "fastq_pass_dir", "protocol_group_id", "instrument", "position", "flow_cell_id", "sample_name", "basecalling_enabled", "started", "acquisition_stopped", "processing_stopped", "fast5_files_in_fallback", "fast5_files_in_final_dest", "fastq_files_in_fallback", "fastq_files_in_final_dest"]
     tbl_rows = []
 
     for e in ts:
         tbl_rows.append([
             e["Files"]["final_summary.txt"],
             e["Files"]["sequencing_summary.txt"],
+            e["Files"]["fast5_pass_dir"],
+            e["Files"]["fastq_pass_dir"],
             e["protocol_group_id"],
             e["instrument"],
             e["position"],
@@ -155,7 +159,7 @@ def update_sample_table(namespace, workspace, buckets, project):
     tbl_old, _ = load_table(namespace, workspace, 'sample')
     tbl_new = load_new_sample_table(buckets, project)
     joined_tbl = merge_tables(tbl_old, tbl_new)
-    joined_tbl = joined_tbl.replace('nan', '', regex=True)
+    joined_tbl = joined_tbl.replace('^nan$', '', regex=True)
 
     return joined_tbl
 

--- a/terra/scripts/update_nanopore_tables.py
+++ b/terra/scripts/update_nanopore_tables.py
@@ -1,10 +1,12 @@
-#!/usr/bin/python3
+#!/usr/bin/env python
 
 import os
 import re
+import math
 import hashlib
 import argparse
 
+import numpy as np
 import pandas as pd
 import firecloud.api as fapi
 
@@ -18,9 +20,35 @@ import xmltodict
 import pprint
 
 
-def load_summaries(gcs_buckets):
-    storage_client = storage.Client(project='broad-dsp-lrma')
-    schemas = OrderedDict()
+pd.set_option('max_columns', 200)
+pd.set_option('max_rows', 200)
+pd.set_option("max_colwidth", None)
+
+
+def load_table(namespace, workspace, table_name, store_membership=False):
+    ent_old = fapi.get_entities(namespace, workspace, table_name).json()
+    tbl_old = None
+
+    membership = None
+    if len(ent_old) > 0:
+        tbl_old = pd.DataFrame(list(map(lambda e: e['attributes'], ent_old)))
+        tbl_old[f"entity:{table_name}_id"] = list(map(lambda f: f['name'], ent_old))
+
+        if store_membership:
+            membership = list(map(lambda g: set(map(lambda h: h['entityName'], g['items'])), tbl_old['samples']))
+            del tbl_old['samples']
+
+        c = list(tbl_old.columns)
+        c.remove(f"entity:{table_name}_id")
+        c = [f"entity:{table_name}_id"] + c
+        tbl_old = tbl_old[c]
+        tbl_old = tbl_old.astype(str)
+
+    return tbl_old, membership
+
+
+def load_summaries(gcs_buckets, project):
+    storage_client = storage.Client(project=project)
 
     ts = []
     for gcs_bucket in gcs_buckets:
@@ -30,22 +58,23 @@ def load_summaries(gcs_buckets):
             if 'final_summary' in blob.name:
                 doc = blob.download_as_string()
                 t = {}
-                
+
                 for line in doc.decode("utf-8").split("\n"):
                     if '=' in line:
-                        k,v = line.split('=')
-                    
+                        k, v = line.split('=')
+
                         t[k] = v
-                        
+
                 t['Files'] = {
                     'final_summary.txt': gcs_bucket + "/" + blob.name,
                     'sequencing_summary.txt': 'missing'
                 }
 
-                bs = storage_client.list_blobs(re.sub("^gs://", "", gcs_bucket), prefix=os.path.dirname(blob.name) + "/" + t['sequencing_summary_file'])
+                bs = storage_client.list_blobs(re.sub("^gs://", "", gcs_bucket),
+                                               prefix=os.path.dirname(blob.name) + "/" + t['sequencing_summary_file'])
                 for b in bs:
                     t['Files']['sequencing_summary.txt'] = gcs_bucket + "/" + b.name
-                    
+
                 if 'sequencing_summary.txt' not in t['Files']:
                     pp = pprint.PrettyPrinter(indent=4)
                     pp.pprint(t)
@@ -55,62 +84,8 @@ def load_summaries(gcs_buckets):
     return ts
 
 
-def upload_data(namespace, workspace, tbl):
-    # delete old sample set
-    ss_old = fapi.get_entities(namespace, workspace, f'sample_set').json()
-    sample_sets = list(map(lambda e: e['name'], ss_old))
-    f = [fapi.delete_sample_set(namespace, workspace, sample_set_index) for sample_set_index in sample_sets]
-    
-    # delete old samples
-    s_old = fapi.get_entities(namespace, workspace, 'sample').json()
-    samples = list(map(lambda e: e['name'], s_old))
-    f = [fapi.delete_sample(namespace, workspace, sample_index) for sample_index in samples]
-
-    # upload new samples
-    a = fapi.upload_entities(namespace, workspace, entity_data=tbl.to_csv(index=False, sep="\t"), model='flexible')
-
-    if a.status_code == 200:
-        print(f'Uploaded {len(tbl)} rows successfully.')
-    else:
-        print(a.json())
-
-    # upload new sample set
-    ss = tbl.filter(['sample_name'], axis=1).drop_duplicates()
-    ss.columns = [f'entity:sample_set_id']
-    
-    b = fapi.upload_entities(namespace, workspace, entity_data=ss.to_csv(index=False, sep="\t"), model='flexible')
-    if b.status_code == 200:
-        print(f'Uploaded {len(ss)} sample sets successfully.')
-    else:
-        print(b.json())
-    
-    # upload membership set
-    ms = tbl.filter(['sample_name', 'entity:sample_id'], axis=1).drop_duplicates()
-    ms.columns = [f'membership:sample_set_id', f'sample']
-    
-    c = fapi.upload_entities(namespace, workspace, entity_data=ms.to_csv(index=False, sep="\t"), model='flexible')
-    if c.status_code == 200:
-        print(f'Uploaded {len(ms)} sample set members successfully.')
-    else:
-        print(c.json())
-
-
-def main():
-    parser = argparse.ArgumentParser(description='Update Terra workspace sample table', prog='update_nanopore_tables')
-    parser.add_argument('-p', '--project', type=str, help="GCP project")
-    parser.add_argument('-n', '--namespace', type=str, help="Terra namespace")
-    parser.add_argument('-w', '--workspace', type=str, help="Terra workspace")
-    parser.add_argument('buckets', metavar='B', type=str, nargs='+', help='GCS buckets to scan')
-    args = parser.parse_args()
-
-    ent_old = fapi.get_entities(args.namespace, args.workspace, 'sample').json()
-    tbl_old = None
-
-    if len(ent_old) > 0:
-        tbl_old = pd.DataFrame(list(map(lambda e: e['attributes'], ent_old)))
-        tbl_old["entity:sample_id"] = list(map(lambda f: hashlib.md5(f.encode("utf-8")).hexdigest(), tbl_old["final_summary_file"]))
-
-    ts = load_summaries(args.buckets)
+def load_new_sample_table(buckets, project):
+    ts = load_summaries(buckets, project)
 
     tbl_header = ["final_summary_file", "sequencing_summary_file", "protocol_group_id", "instrument", "position", "flow_cell_id", "sample_name", "basecalling_enabled", "started", "acquisition_stopped", "processing_stopped", "fast5_files_in_fallback", "fast5_files_in_final_dest", "fastq_files_in_fallback", "fastq_files_in_final_dest"]
     tbl_rows = []
@@ -136,7 +111,12 @@ def main():
 
     tbl_new = pd.DataFrame(tbl_rows, columns=tbl_header)
     tbl_new["entity:sample_id"] = list(map(lambda f: hashlib.md5(f.encode("utf-8")).hexdigest(), tbl_new["final_summary_file"]))
+    tbl_new = tbl_new.astype(str)
 
+    return tbl_new
+
+
+def merge_tables(tbl_old, tbl_new):
     if tbl_old is not None:
         outer_tbl = pd.merge(tbl_old, tbl_new, how='outer', sort=True, indicator=True)
     else:
@@ -144,30 +124,112 @@ def main():
 
     hs = []
     for l in list(outer_tbl['entity:sample_id'].unique()):
-        g = outer_tbl.loc[outer_tbl['entity:sample_id'] == l]
+        g = outer_tbl.loc[outer_tbl['entity:sample_id'] == l].sort_values('_merge')
 
         if len(g) == 1:
             hs.append(g.iloc[0].to_dict())
         else:
             h = {}
             for col_name in list(outer_tbl.columns):
-                side = "left_only" if col_name in list(tbl_old.columns) else "right_only"
-                q = list(g.loc[g['_merge'] == side][col_name])
-                if len(q) > 0:
-                    h[col_name] = q[0]
+                q = g[col_name]
+                v = q.where((q != 'None') & (q != 'nan')).dropna()
+                h[col_name] = v.iloc[0] if len(v) > 0 else ''
 
             hs.append(h)
 
     joined_tbl = pd.DataFrame(hs)
+
     if '_merge' in joined_tbl:
         del joined_tbl['_merge']
-
     c = list(joined_tbl.columns)
     c.remove("entity:sample_id")
     c = ["entity:sample_id"] + c
     joined_tbl = joined_tbl[c]
 
-    upload_data(args.namespace, args.workspace, joined_tbl)
+    joined_tbl['sample_name'] = joined_tbl['sample_name'].str.replace(r'\s+', ' ', regex=True).astype('str')
+
+    return joined_tbl
+
+
+def update_sample_table(namespace, workspace, buckets, project):
+    tbl_old, _ = load_table(namespace, workspace, 'sample')
+    tbl_new = load_new_sample_table(buckets, project)
+    joined_tbl = merge_tables(tbl_old, tbl_new)
+    joined_tbl = joined_tbl.replace('nan', '', regex=True)
+
+    return joined_tbl
+
+
+def update_sample_set_table(namespace, workspace, joined_tbl):
+    ss_old, membership = load_table(namespace, workspace, 'sample_set', store_membership=True)
+
+    # create old membership set
+    oms = pd \
+        .DataFrame({'entity:sample_set_id': list(ss_old['entity:sample_set_id']), 'sample': membership}) \
+        .explode('sample', ignore_index=True)
+    oms.columns = ['membership:sample_set_id', 'sample']
+
+    # create sample set
+    ss = joined_tbl.filter(['sample_name'], axis=1).drop_duplicates()
+    ss.columns = [f'entity:sample_set_id']
+
+    if ss_old is not None:
+        ss = pd.merge(ss_old, ss, how='outer', sort=True)
+    ss = ss.replace('nan', '', regex=True)
+
+    # create new membership set
+    ms = joined_tbl.filter(['sample_name', 'entity:sample_id'], axis=1).drop_duplicates()
+    ms.columns = [f'membership:sample_set_id', f'sample']
+
+    # create full membership set
+    fms = pd.merge(ms, oms, how='outer', indicator=True)
+
+    # create new/modified membership set
+    nms = fms[fms['_merge'] != 'both']
+
+    return ss, nms
+
+
+def upload_table(namespace, workspace, table, label):
+    # upload new samples
+    a = fapi.upload_entities(namespace, workspace, entity_data=table.to_csv(index=False, sep="\t"), model='flexible')
+
+    if a.status_code == 200:
+        print(f'Uploaded {len(table)} {label} rows successfully.')
+    else:
+        print(a.json())
+
+
+def upload_tables(namespace, workspace, s, ss, nms):
+    for ssname in list(nms[nms['_merge'] == 'right_only']['membership:sample_set_id']):
+        a = fapi.delete_sample_set(namespace, workspace, ssname)
+
+        if a.status_code == 204:
+            print(f'Removed out-of-date sample set {ssname} successfully.')
+        else:
+            print(a.json())
+
+    lms = nms[nms['_merge'] == 'left_only'][['membership:sample_set_id', 'sample']]
+
+    upload_table(namespace, workspace, s, 'sample')
+    upload_table(namespace, workspace, ss, 'sample_set')
+    upload_table(namespace, workspace, lms, 'sample_set membership')
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Update Terra workspace sample table', prog='update_nanopore_tables')
+    parser.add_argument('-p', '--project', type=str, help="GCP project")
+    parser.add_argument('-n', '--namespace', type=str, help="Terra namespace")
+    parser.add_argument('-w', '--workspace', type=str, help="Terra workspace")
+    parser.add_argument('-r', '--run', action='store_true', help="Turn off the default dry-run mode")
+    parser.add_argument('buckets', metavar='B', type=str, nargs='+', help='GCS buckets to scan')
+    args = parser.parse_args()
+
+    s = update_sample_table(args.namespace, args.workspace, args.buckets, args.project)
+    ss, nms = update_sample_set_table(args.namespace, args.workspace, s)
+
+    if args.run:
+        upload_tables(args.namespace, args.workspace, s, ss, nms)
 
 
 if __name__ == "__main__":

--- a/terra/scripts/update_pacbio_tables.py
+++ b/terra/scripts/update_pacbio_tables.py
@@ -304,7 +304,7 @@ def update_sample_table(namespace, workspace, buckets, project):
     tbl_old, _ = load_table(namespace, workspace, 'sample')
     tbl_new = load_new_sample_table(buckets, project)
     joined_tbl = merge_tables(tbl_old, tbl_new)
-    joined_tbl = joined_tbl.replace('nan', '', regex=True)
+    joined_tbl = joined_tbl.replace('^nan$', '', regex=True)
 
     return joined_tbl
 

--- a/terra/scripts/update_pacbio_tables.py
+++ b/terra/scripts/update_pacbio_tables.py
@@ -25,21 +25,26 @@ pd.set_option('max_rows', 200)
 pd.set_option("max_colwidth", None)
 
 
-def load_table(namespace, workspace, table_name):
+def load_table(namespace, workspace, table_name, store_membership=False):
     ent_old = fapi.get_entities(namespace, workspace, table_name).json()
     tbl_old = None
 
+    membership = None
     if len(ent_old) > 0:
         tbl_old = pd.DataFrame(list(map(lambda e: e['attributes'], ent_old)))
         tbl_old[f"entity:{table_name}_id"] = list(map(lambda f: f['name'], ent_old))
-        tbl_old = tbl_old.astype(str)
+
+        if store_membership:
+            membership = list(map(lambda g: set(map(lambda h: h['entityName'], g['items'])), tbl_old['samples']))
+            del tbl_old['samples']
 
         c = list(tbl_old.columns)
         c.remove(f"entity:{table_name}_id")
         c = [f"entity:{table_name}_id"] + c
         tbl_old = tbl_old[c]
+        tbl_old = tbl_old.astype(str)
 
-    return tbl_old
+    return tbl_old, membership
 
 
 def load_new_sample_table(buckets, project):
@@ -61,7 +66,8 @@ def load_new_sample_table(buckets, project):
             experiment_type = "ISOSEQ"
 
         input_bam = e['Files']['subreads.bam'] if e['Files']['subreads.bam'] != "" else e['Files']['reads.bam']
-        input_pbi = e['Files']['subreads.bam.pbi'] if e['Files']['subreads.bam.pbi'] != "" else e['Files']['reads.bam.pbi']
+        input_pbi = e['Files']['subreads.bam.pbi'] if e['Files']['subreads.bam.pbi'] != "" else e['Files'][
+            'reads.bam.pbi']
 
         tbl_rows.append([
             e['CollectionMetadata'][0]['UniqueId'] if 'Context' in e['CollectionMetadata'][0] else "",
@@ -119,7 +125,7 @@ def merge_tables(tbl_old, tbl_new):
 
     hs = []
     for l in list(outer_tbl['entity:sample_id'].unique()):
-        g = outer_tbl.loc[outer_tbl['entity:sample_id'] == l]
+        g = outer_tbl.loc[outer_tbl['entity:sample_id'] == l].sort_values('_merge')
 
         if len(g) == 1:
             hs.append(g.iloc[0].to_dict())
@@ -141,9 +147,9 @@ def merge_tables(tbl_old, tbl_new):
     c = ["entity:sample_id"] + c
     joined_tbl = joined_tbl[c]
 
-    joined_tbl['description'] = joined_tbl['description'].str.replace(r'\s+', ' ').astype('str')
-    joined_tbl['bio_sample'] = joined_tbl['bio_sample'].str.replace(r'\s+', ' ').astype('str')
-    joined_tbl['well_sample'] = joined_tbl['well_sample'].str.replace(r'\s+', ' ').astype('str')
+    joined_tbl['description'] = joined_tbl['description'].str.replace(r'\s+', ' ', regex=True).astype('str')
+    joined_tbl['bio_sample'] = joined_tbl['bio_sample'].str.replace(r'\s+', ' ', regex=True).astype('str')
+    joined_tbl['well_sample'] = joined_tbl['well_sample'].str.replace(r'\s+', ' ', regex=True).astype('str')
 
     return joined_tbl
 
@@ -231,81 +237,14 @@ def load_xmls(gcs_buckets, project):
                     'subreads.bam.pbi': "",
 
                     'consensusreadset.xml': gcs_bucket + "/" + blob.name,
-                    'ccs_reports.txt': gcs_bucket + "/" + re.sub(".consensusreadset.xml", ".ccs_reports.txt", blob.name),
+                    'ccs_reports.txt': gcs_bucket + "/" + re.sub(".consensusreadset.xml", ".ccs_reports.txt",
+                                                                 blob.name),
                     'reads.bam': gcs_bucket + "/" + re.sub(".consensusreadset.xml", ".reads.bam", blob.name),
                     'reads.bam.pbi': gcs_bucket + "/" + re.sub(".consensusreadset.xml", ".reads.bam.pbi", blob.name)
                 }
                 ts.append(t)
 
     return ts
-
-
-def update_sample_table(namespace, workspace, buckets, project):
-    tbl_old = load_table(namespace, workspace, 'sample')
-    tbl_new = load_new_sample_table(buckets, project)
-    joined_tbl = merge_tables(tbl_old, tbl_new)
-    joined_tbl = joined_tbl.replace('nan', '', regex=True)
-
-    return joined_tbl
-
-
-def update_sample_set_table(namespace, workspace, joined_tbl):
-    ss_old = load_table(namespace, workspace, 'sample_set')
-
-    # create sample set
-    ss = joined_tbl.filter(['bio_sample'], axis=1).drop_duplicates()
-    ss.columns = [f'entity:sample_set_id']
-    if ss_old is not None:
-        del ss_old['samples']
-        ss = pd.merge(ss_old, ss, how='outer', sort=True)
-    ss = ss.replace('nan', '', regex=True)
-
-    # create membership set
-    ms = joined_tbl.filter(['bio_sample', 'entity:sample_id'], axis=1).drop_duplicates()
-    ms.columns = [f'membership:sample_set_id', f'sample']
-    ms = ms.replace('nan', '', regex=True)
-
-    return ss, ms
-
-
-def delete_table(namespace, workspace, table_name):
-    # delete old table
-    t_old = fapi.get_entities(namespace, workspace, table_name).json()
-    names = list(map(lambda e: e['name'], t_old))
-    f = [fapi.delete_sample_set(namespace, workspace, name) for name in names]
-
-    return f
-
-
-def update_table(namespace, workspace, table):
-    # upload new samples
-    a = fapi.upload_entities(namespace, workspace, entity_data=table.to_csv(index=False, sep="\t"), model='flexible')
-
-    if a.status_code == 200:
-        print(f'Uploaded {len(table)} rows successfully.')
-    else:
-        print(a.json())
-
-
-def upload_data(namespace, workspace, s, ss, ms):
-    #delete_table(namespace, workspace, 'sample_set')
-    #delete_table(namespace, workspace, 'sample')
-
-    update_table(namespace, workspace, s)
-    #update_table(namespace, workspace, ss)
-    #update_table(namespace, workspace, ms)
-
-    ent_old = fapi.get_entities(namespace, workspace, 'sample_set').json()
-    existing_entries = list(map(lambda f: f['name'], ent_old))
-
-    if len(ent_old) > 0:
-        tbl_old = pd.DataFrame(list(map(lambda e: e['attributes'], ent_old)))
-        tbl_old[f"entity:sample_set_id"] = list(map(lambda f: f['name'], ent_old))
-
-    t_old = fapi.get_entities(namespace, workspace, 'sample_set').json()
-
-    return
-    #f = [fapi.delete_sample_set(namespace, workspace, name) for name in names]
 
 
 def load_ccs_report(project, ccs_report_path, e):
@@ -361,6 +300,71 @@ def load_ccs_report(project, ccs_report_path, e):
     return d
 
 
+def update_sample_table(namespace, workspace, buckets, project):
+    tbl_old, _ = load_table(namespace, workspace, 'sample')
+    tbl_new = load_new_sample_table(buckets, project)
+    joined_tbl = merge_tables(tbl_old, tbl_new)
+    joined_tbl = joined_tbl.replace('nan', '', regex=True)
+
+    return joined_tbl
+
+
+def update_sample_set_table(namespace, workspace, joined_tbl):
+    ss_old, membership = load_table(namespace, workspace, 'sample_set', store_membership=True)
+
+    # create old membership set
+    oms = pd \
+        .DataFrame({'entity:sample_set_id': list(ss_old['entity:sample_set_id']), 'sample': membership}) \
+        .explode('sample', ignore_index=True)
+    oms.columns = ['membership:sample_set_id', 'sample']
+
+    # create sample set
+    ss = joined_tbl.filter(['bio_sample'], axis=1).drop_duplicates()
+    ss.columns = [f'entity:sample_set_id']
+
+    if ss_old is not None:
+        ss = pd.merge(ss_old, ss, how='outer', sort=True)
+    ss = ss.replace('nan', '', regex=True)
+
+    # create new membership set
+    ms = joined_tbl.filter(['bio_sample', 'entity:sample_id'], axis=1).drop_duplicates()
+    ms.columns = [f'membership:sample_set_id', f'sample']
+
+    # create full membership set
+    fms = pd.merge(ms, oms, how='outer', indicator=True)
+
+    # create new/modified membership set
+    nms = fms[fms['_merge'] != 'both']
+
+    return ss, nms
+
+
+def upload_table(namespace, workspace, table, label):
+    # upload new samples
+    a = fapi.upload_entities(namespace, workspace, entity_data=table.to_csv(index=False, sep="\t"), model='flexible')
+
+    if a.status_code == 200:
+        print(f'Uploaded {len(table)} {label} rows successfully.')
+    else:
+        print(a.json())
+
+
+def upload_tables(namespace, workspace, s, ss, nms):
+    for ssname in list(nms[nms['_merge'] == 'right_only']['membership:sample_set_id']):
+        a = fapi.delete_sample_set(namespace, workspace, ssname)
+
+        if a.status_code == 204:
+            print(f'Removed out-of-date sample set {ssname} successfully.')
+        else:
+            print(a.json())
+
+    lms = nms[nms['_merge'] == 'left_only'][['membership:sample_set_id', 'sample']]
+
+    upload_table(namespace, workspace, s, 'sample')
+    upload_table(namespace, workspace, ss, 'sample_set')
+    upload_table(namespace, workspace, lms, 'sample_set membership')
+
+
 def main():
     parser = argparse.ArgumentParser(description='Update Terra workspace sample table', prog='update_pacbio_tables')
     parser.add_argument('-p', '--project', type=str, help="GCP project")
@@ -371,10 +375,10 @@ def main():
     args = parser.parse_args()
 
     s = update_sample_table(args.namespace, args.workspace, args.buckets, args.project)
-    ss, ms = update_sample_set_table(args.namespace, args.workspace, s)
+    ss, nms = update_sample_set_table(args.namespace, args.workspace, s)
 
     if args.run:
-        upload_data(args.namespace, args.workspace, s, ss, ms)
+        upload_tables(args.namespace, args.workspace, s, ss, nms)
 
 
 if __name__ == "__main__":

--- a/terra/scripts/update_pacbio_tables.py
+++ b/terra/scripts/update_pacbio_tables.py
@@ -324,7 +324,7 @@ def update_sample_set_table(namespace, workspace, joined_tbl):
 
     if ss_old is not None:
         ss = pd.merge(ss_old, ss, how='outer', sort=True)
-    ss = ss.replace('nan', '', regex=True)
+    ss = ss.replace('^nan$', '', regex=True)
 
     # create new membership set
     ms = joined_tbl.filter(['bio_sample', 'entity:sample_id'], axis=1).drop_duplicates()


### PR DESCRIPTION
1. Fixed an issue where, when updating rows that include manual edits from Terra, an inconsistent sort order caused values to be randomly assigned.
2. While sample tables can be changed by simply uploading a new version, the sample set membership table seems to just add redundant entries, potentially causing downstream problems.  Fixed by only uploading the changed membership entries, rather than the full table.
3. When manual edits in the sample table cause sample_set entries to be invalidated, remove the invalid sample_set entries.