### PR TITLE
[WIP] Pipeline to generate variant review reports

### DIFF
--- a/docker/lr-bwa-mem2/Dockerfile
+++ b/docker/lr-bwa-mem2/Dockerfile
@@ -1,0 +1,4 @@
+FROM mambaorg/micromamba:0.14.0
+COPY environment.yml /root/env.yaml
+RUN micromamba install -y -n base -f /root/env.yaml && \
+    micromamba clean --all --yes

--- a/docker/lr-bwa-mem2/Makefile
+++ b/docker/lr-bwa-mem2/Makefile
@@ -1,0 +1,16 @@
+VERSION = 2.2.1 # This should match the actual bwa-mem2 version
+TAG1 = quay.io/broad-long-read-pipelines/lr-bwa-mem2:$(VERSION)
+TAG2 = quay.io/broad-long-read-pipelines/lr-bwa-mem2:latest
+TAG3 = us.gcr.io/broad-dsp-lrma/lr-bwa-mem2:$(VERSION)
+TAG4 = us.gcr.io/broad-dsp-lrma/lr-bwa-mem2:latest
+
+all: build push
+
+build:
+	docker build -t $(TAG1) -t $(TAG2) -t $(TAG3) -t $(TAG4) .
+
+push:
+	docker push $(TAG1)
+	docker push $(TAG2)
+	docker push $(TAG3)
+	docker push $(TAG4)

--- a/docker/lr-bwa-mem2/environment.yml
+++ b/docker/lr-bwa-mem2/environment.yml
@@ -1,0 +1,8 @@
+name: base
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - samtools
+  - bwa-mem2

--- a/docker/lr-wga/Dockerfile
+++ b/docker/lr-wga/Dockerfile
@@ -1,0 +1,4 @@
+FROM mambaorg/micromamba:0.14.0
+COPY environment.yml /root/env.yaml
+RUN micromamba install -y -n base -f /root/env.yaml && \
+    micromamba clean --all --yes

--- a/docker/lr-wga/Makefile
+++ b/docker/lr-wga/Makefile
@@ -1,0 +1,16 @@
+VERSION = 0.1.0
+TAG1 = quay.io/broad-long-read-pipelines/lr-wga:$(VERSION)
+TAG2 = quay.io/broad-long-read-pipelines/lr-wga:latest
+TAG3 = us.gcr.io/broad-dsp-lrma/lr-wga:$(VERSION)
+TAG4 = us.gcr.io/broad-dsp-lrma/lr-wga:latest
+
+all: build push
+
+build:
+	docker build -t $(TAG1) -t $(TAG2) -t $(TAG3) -t $(TAG4) .
+
+push:
+	docker push $(TAG1)
+	docker push $(TAG2)
+	docker push $(TAG3)
+	docker push $(TAG4)

--- a/docker/lr-wga/environment.yml
+++ b/docker/lr-wga/environment.yml
@@ -1,0 +1,9 @@
+name: base
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - samtools
+  - minimap2
+  - mummer4

--- a/wdl/PrepareVarReview.wdl
+++ b/wdl/PrepareVarReview.wdl
@@ -1,0 +1,143 @@
+version 1.0
+
+import "tasks/Structs.wdl"
+import "tasks/BWA.wdl" as BWA
+import "tasks/AlignReads.wdl" as AlignReads
+import "tasks/WGA.wdl" as WGA
+
+# This workflow aids in building a variant calling truth set, by comparing two (high quality) assemblies
+# with tools like mummer and minimap2. This workflow then generates several plots and reports for each variant
+# identified which can be used to manually validate each variant.
+
+workflow PrepareVarReview {
+    input {
+        String sample1
+        String sample2
+
+        File ref1
+        File ref2
+
+        File? ref1_gff
+
+        Array[File]+ s1_illumina_reads
+        File? s1_nanopore_reads
+        File? s1_pacbio_reads
+
+        Array[File]+ s2_illumina_reads
+        File? s2_nanopore_reads
+        File? s2_pacbio_reads
+    }
+
+    parameter_meta {
+        sample1: "Name of the first sample (e.g. strain name)"
+        sample2: "Name of the second sample (e.g. strain name)"
+
+        ref1: "FASTA file containing the assembled genome of sample 1"
+        ref2: "FASTA file containing the assembled genome of sample 2"
+
+        ref1_gff: "Gene annotations for the first reference, to be displayed in variant review reports"
+
+        s1_illumina_reads: "Illumina read data from sample 1."
+        s1_nanopore_reads: "Oxford nanopore reads from sample 1."
+        s1_pacbio_reads: "Pacbio reads from sample 1."
+
+        s2_illumina_reads: "Illumina read data from sample 2."
+        s2_nanopore_reads: "Oxford nanopore reads from sample 2."
+        s2_pacbio_reads: "Pacbio reads from sample 2."
+    }
+
+    # Read alignments to both references
+    # ----------------------------------
+    #
+    
+    call BWA.BWAMem2Align as S1_SelfAlignmentIllumina {
+        input: ref=ref1, reads=s1_illumina_reads, output_prefix="self_alignment/illumina/~{sample1}"
+    }
+
+    call BWA.BWAMem2Align as S2_SelfAlignmentIllumina {
+        input: ref=ref2, reads=s2_illumina_reads, output_prefix="self_alignment/illumina/~{sample2}"
+    }
+
+    call BWA.BWAMem2Align as S2_to_S1_Illumina {
+        input: ref=ref1, reads=s2_illumina_reads, output_prefix="alignments/illumina/~{sample2}_to_~{sample1}"
+    }
+
+    call BWA.BWAMem2Align as S1_to_S2_Illumina {
+        input: ref=ref2, reads=s1_illumina_reads, output_prefix="alignments/illumina/~{sample1}_to_~{sample2}"
+    }
+
+    if(defined(s1_nanopore_reads)) {
+        File np_reads_s1 = select_first([s1_nanopore_reads])
+
+        # Self alignment
+        call AlignReads.Minimap2 as S1_SelfAlignmentNanopore {
+            input: ref_fasta=ref1, reads=[np_reads_s1], RG="''", map_preset="map-ont",
+                prefix="self_alignment/oxford_nanopore/~{sample1}"
+        }
+
+        # Cross alignment
+        call AlignReads.Minimap2 as S1_to_S2_Nanopore {
+            input: ref_fasta=ref2, reads=[np_reads_s1], RG="''", map_preset="map-ont",
+                prefix="alignments/oxford_nanopore/~{sample1}_to_~{sample2}"
+        }
+    }
+
+    if(defined(s1_pacbio_reads)) {
+        File pb_reads_s1 = select_first([s1_pacbio_reads])
+
+        # Self alignment
+        call AlignReads.Minimap2 as S1_SelfAlignmentPacBio {
+            input: ref_fasta=ref1, reads=[pb_reads_s1], RG="''", map_preset="map-pb",
+            prefix="self_alignment/pacbio/~{sample1}"
+        }
+
+        # Cross alignment
+        call AlignReads.Minimap2 as S1_to_S2_PacBio {
+            input: ref_fasta=ref2, reads=[pb_reads_s1], RG="''", map_preset="map-pb",
+                prefix="alignments/pacbio/~{sample1}_to_~{sample2}"
+        }
+    }
+
+    if(defined(s2_nanopore_reads)) {
+        File np_reads_s2 = select_first([s2_nanopore_reads])
+
+        # Self-alignment
+        call AlignReads.Minimap2 as S2_SelfAlignmentNanopore {
+            input: ref_fasta=ref2, reads=[np_reads_s2], RG="''", map_preset="map-ont",
+                prefix="self_alignment/oxford_nanopore/~{sample2}"
+        }
+
+        # Cross alignment
+        call AlignReads.Minimap2 as S2_to_S1_Nanopore {
+            input: ref_fasta=ref1, reads=[np_reads_s2], RG="''", map_preset="map-ont",
+                prefix="alignments/oxford_nanopore/~{sample2}_to_~{sample1}"
+        }
+    }
+
+    if(defined(s2_pacbio_reads)) {
+        File pb_reads_s2 = select_first([s2_pacbio_reads])
+
+        # Self-alignment
+        call AlignReads.Minimap2 as S2_SelfAlignmentPacBio {
+            input: ref_fasta=ref2, reads=[pb_reads_s2], RG="''", map_preset="map-pb",
+            prefix="self_alignment/pacbio/~{sample2}"
+        }
+
+        # Cross alignment
+        call AlignReads.Minimap2 as S2_to_S1_PacBio {
+            input: ref_fasta=ref1, reads=[pb_reads_s2], RG="''", map_preset="map-pb",
+                prefix="alignments/pacbio/~{sample2}_to_~{sample1}"
+        }
+    }
+
+    # Whole genome alignments with Nucmer and Minimap2
+    # ------------------------------------------------
+    # 
+    call WGA.Minimap2 as S2_to_S1_MinimapWGA {
+        input: ref1=ref1, ref2=ref2, prefix="wga/~{sample2}_to_~{sample1}"
+    }
+
+    call WGA.Nucmer as S2_to_S1_NucmerWGA {
+        input: ref1=ref1, ref2=ref2, prefix="wga/~{sample2}_to_~{sample1}"
+    }
+}

--- a/wdl/PrepareVarReview.wdl
+++ b/wdl/PrepareVarReview.wdl
@@ -4,6 +4,7 @@ import "tasks/Structs.wdl"
 import "tasks/BWA.wdl" as BWA
 import "tasks/AlignReads.wdl" as AlignReads
 import "tasks/WGA.wdl" as WGA
+import "tasks/Finalize.wdl" as FF
 
 # This workflow aids in building a variant calling truth set, by comparing two (high quality) assemblies
 # with tools like mummer and minimap2. This workflow then generates several plots and reports for each variant
@@ -26,7 +27,11 @@ workflow PrepareVarReview {
         Array[File]+ s2_illumina_reads
         File? s2_nanopore_reads
         File? s2_pacbio_reads
+
+        String output_dir
     }
+
+    String gcs_output_dir = sub(output_dir, "/+$", "")
 
     parameter_meta {
         sample1: "Name of the first sample (e.g. strain name)"
@@ -51,19 +56,19 @@ workflow PrepareVarReview {
     #
     
     call BWA.BWAMem2Align as S1_SelfAlignmentIllumina {
-        input: ref=ref1, reads=s1_illumina_reads, output_prefix="self_alignment/illumina/~{sample1}"
+        input: ref=ref1, reads=s1_illumina_reads, output_prefix="illumina_self_~{sample1}"
     }
 
     call BWA.BWAMem2Align as S2_SelfAlignmentIllumina {
-        input: ref=ref2, reads=s2_illumina_reads, output_prefix="self_alignment/illumina/~{sample2}"
+        input: ref=ref2, reads=s2_illumina_reads, output_prefix="illumina_self_~{sample2}"
     }
 
     call BWA.BWAMem2Align as S2_to_S1_Illumina {
-        input: ref=ref1, reads=s2_illumina_reads, output_prefix="alignments/illumina/~{sample2}_to_~{sample1}"
+        input: ref=ref1, reads=s2_illumina_reads, output_prefix="illumina_~{sample2}_to_~{sample1}"
     }
 
     call BWA.BWAMem2Align as S1_to_S2_Illumina {
-        input: ref=ref2, reads=s1_illumina_reads, output_prefix="alignments/illumina/~{sample1}_to_~{sample2}"
+        input: ref=ref2, reads=s1_illumina_reads, output_prefix="illumina_~{sample1}_to_~{sample2}"
     }
 
     if(defined(s1_nanopore_reads)) {
@@ -71,14 +76,14 @@ workflow PrepareVarReview {
 
         # Self alignment
         call AlignReads.Minimap2 as S1_SelfAlignmentNanopore {
-            input: ref_fasta=ref1, reads=[np_reads_s1], RG="''", map_preset="map-ont",
-                prefix="self_alignment/oxford_nanopore/~{sample1}"
+            input: ref_fasta=ref1, reads=[np_reads_s1], map_preset="map-ont",
+                prefix="ont_self_~{sample1}"
         }
 
         # Cross alignment
         call AlignReads.Minimap2 as S1_to_S2_Nanopore {
-            input: ref_fasta=ref2, reads=[np_reads_s1], RG="''", map_preset="map-ont",
-                prefix="alignments/oxford_nanopore/~{sample1}_to_~{sample2}"
+            input: ref_fasta=ref2, reads=[np_reads_s1], map_preset="map-ont",
+                prefix="ont_~{sample1}_to_~{sample2}"
         }
     }
 
@@ -87,14 +92,14 @@ workflow PrepareVarReview {
 
         # Self alignment
         call AlignReads.Minimap2 as S1_SelfAlignmentPacBio {
-            input: ref_fasta=ref1, reads=[pb_reads_s1], RG="''", map_preset="map-pb",
-            prefix="self_alignment/pacbio/~{sample1}"
+            input: ref_fasta=ref1, reads=[pb_reads_s1], map_preset="map-pb",
+            prefix="pb_self_~{sample1}"
         }
 
         # Cross alignment
         call AlignReads.Minimap2 as S1_to_S2_PacBio {
-            input: ref_fasta=ref2, reads=[pb_reads_s1], RG="''", map_preset="map-pb",
-                prefix="alignments/pacbio/~{sample1}_to_~{sample2}"
+            input: ref_fasta=ref2, reads=[pb_reads_s1], map_preset="map-pb",
+                prefix="pb_~{sample1}_to_~{sample2}"
         }
     }
 
@@ -103,14 +108,14 @@ workflow PrepareVarReview {
 
         # Self-alignment
         call AlignReads.Minimap2 as S2_SelfAlignmentNanopore {
-            input: ref_fasta=ref2, reads=[np_reads_s2], RG="''", map_preset="map-ont",
-                prefix="self_alignment/oxford_nanopore/~{sample2}"
+            input: ref_fasta=ref2, reads=[np_reads_s2], map_preset="map-ont",
+                prefix="ont_self_~{sample2}"
         }
 
         # Cross alignment
         call AlignReads.Minimap2 as S2_to_S1_Nanopore {
-            input: ref_fasta=ref1, reads=[np_reads_s2], RG="''", map_preset="map-ont",
-                prefix="alignments/oxford_nanopore/~{sample2}_to_~{sample1}"
+            input: ref_fasta=ref1, reads=[np_reads_s2], map_preset="map-ont",
+                prefix="ont_~{sample2}_to_~{sample1}"
         }
     }
 
@@ -119,14 +124,14 @@ workflow PrepareVarReview {
 
         # Self-alignment
         call AlignReads.Minimap2 as S2_SelfAlignmentPacBio {
-            input: ref_fasta=ref2, reads=[pb_reads_s2], RG="''", map_preset="map-pb",
-            prefix="self_alignment/pacbio/~{sample2}"
+            input: ref_fasta=ref2, reads=[pb_reads_s2], map_preset="map-pb",
+            prefix="pb_self_~{sample2}"
         }
 
         # Cross alignment
         call AlignReads.Minimap2 as S2_to_S1_PacBio {
-            input: ref_fasta=ref1, reads=[pb_reads_s2], RG="''", map_preset="map-pb",
-                prefix="alignments/pacbio/~{sample2}_to_~{sample1}"
+            input: ref_fasta=ref1, reads=[pb_reads_s2], map_preset="map-pb",
+                prefix="pb_~{sample2}_to_~{sample1}"
         }
     }
 
@@ -134,10 +139,332 @@ workflow PrepareVarReview {
     # ------------------------------------------------
     # 
     call WGA.Minimap2 as S2_to_S1_MinimapWGA {
-        input: ref1=ref1, ref2=ref2, prefix="wga/~{sample2}_to_~{sample1}"
+        input: ref1=ref1, ref2=ref2, prefix="wga_~{sample2}_to_~{sample1}_minimap2"
     }
 
     call WGA.Nucmer as S2_to_S1_NucmerWGA {
-        input: ref1=ref1, ref2=ref2, prefix="wga/~{sample2}_to_~{sample1}"
+        input: ref1=ref1, ref2=ref2, prefix="wga_~{sample2}_to_~{sample1}_nucmer"
+    }
+
+    call CallVariantsNucmer {
+        input: reference=ref1, query=ref2, delta=S2_to_S1_NucmerWGA.filtered_delta, 
+            prefix="~{sample2}_to_~{sample1}.nucmer"
+    }
+
+    call CallVariantsMinimap2 {
+        input: reference=ref1, query=ref2, prefix="~{sample2}_to_~{sample1}.minimap2"
+    }
+
+    call MergeVcfs {
+        input: vcf1=CallVariantsMinimap2.vcf, vcf2=CallVariantsNucmer.vcf,
+            prefix="~{sample2}_to_~{sample1}.merged"
+    }
+
+    Array[File] bams = select_all([
+        S2_to_S1_Illumina.aligned_bam,
+        S2_to_S1_Nanopore.aligned_bam,
+        S2_to_S1_PacBio.aligned_bam
+    ])
+    Array[String] names = select_all([
+        "Illumina",
+        if(defined(s2_nanopore_reads)) then "Nanopore" else "",
+        if(defined(s2_pacbio_reads)) then "PacBio" else "", 
+    ])
+
+    scatter(bam in bams) {
+        File bais = bam + ".bai"
+    }
+
+    call SVPlots {
+        input: reference=ref1, query=ref2, delta=S2_to_S1_NucmerWGA.filtered_delta, vcf=MergeVcfs.bcf,
+            bams=bams, bais=bais, names=names
+    }
+
+    call FF.FinalizeToDir as FinalizeIllumina {
+        input: files=[
+            S1_SelfAlignmentIllumina.aligned_bam,
+            S1_SelfAlignmentIllumina.aligned_bai,
+            S2_SelfAlignmentIllumina.aligned_bam,
+            S2_SelfAlignmentIllumina.aligned_bai,
+
+            S2_to_S1_Illumina.aligned_bam,
+            S2_to_S1_Illumina.aligned_bai,
+            S1_to_S2_Illumina.aligned_bam,
+            S1_to_S2_Illumina.aligned_bai
+        ], outdir=gcs_output_dir + "/illumina"
+    }
+
+    Array[File] s1_ont_files = select_all([
+        S1_SelfAlignmentNanopore.aligned_bam,
+        S1_SelfAlignmentNanopore.aligned_bai,
+        S1_to_S2_Nanopore.aligned_bam,
+        S1_to_S2_Nanopore.aligned_bai
+    ])
+
+    Array[File] s2_ont_files = select_all([
+        S2_SelfAlignmentNanopore.aligned_bam,
+        S2_SelfAlignmentNanopore.aligned_bai,
+        S2_to_S1_Nanopore.aligned_bam,
+        S2_to_S1_Nanopore.aligned_bai
+    ])
+
+    Array[File] s1_pb_files = select_all([
+        S1_SelfAlignmentNanopore.aligned_bam,
+        S1_SelfAlignmentNanopore.aligned_bai,
+        S1_to_S2_Nanopore.aligned_bam,
+        S1_to_S2_Nanopore.aligned_bai
+    ])
+
+    Array[File] s2_pb_files = select_all([
+        S2_SelfAlignmentPacBio.aligned_bam,
+        S2_SelfAlignmentPacBio.aligned_bai,
+        S2_to_S1_PacBio.aligned_bam,
+        S2_to_S1_PacBio.aligned_bai
+    ])
+
+    Array[File] ont_files = flatten([s1_ont_files, s2_ont_files])
+    Array[File] pb_files = flatten([s2_pb_files, s2_pb_files])
+
+    if(length(ont_files) > 0) {
+        call FF.FinalizeToDir as FinalizeONT {
+            input: files=ont_files, outdir=gcs_output_dir + "/oxford_nanopore"
+        }
+    }
+
+    if(length(pb_files) > 0) {
+        call FF.FinalizeToDir as FinalizePB {
+            input: files=pb_files, outdir=gcs_output_dir + "/pacbio"
+        }
+    }
+
+    call FF.FinalizeToDir as FinalizeWGA {
+        input: files=[
+            S2_to_S1_NucmerWGA.delta,
+            S2_to_S1_NucmerWGA.filtered_delta,
+            S2_to_S1_MinimapWGA.wga_bam,
+            S2_to_S1_MinimapWGA.wga_bai
+        ], outdir=gcs_output_dir + "/wga"
+    }
+            
+    call FF.FinalizeToDir as FinalizeVariants {
+        input: files=[
+            CallVariantsNucmer.vcf,
+            CallVariantsNucmer.insertions_fasta,
+            CallVariantsMinimap2.vcf,
+            MergeVcfs.bcf,
+            MergeVcfs.tbi
+        ], outdir=gcs_output_dir
+    }
+
+    call FF.FinalizeToDir as FinalizePlots {
+        input: files=SVPlots.plots, outdir=gcs_output_dir + "/review/plots"
+    }
+
+}
+
+task CallVariantsNucmer {
+    input {
+        File reference
+        File query
+        File delta
+
+        String prefix
+
+        RuntimeAttr? runtime_attr_override
+    }
+
+    output {
+        File vcf = "~{prefix}.vcf"
+        File insertions_fasta = "~{prefix}.insertions.fasta"
+    }
+
+    command <<<
+        set -euxo pipefail
+
+        # Ensure correct file paths in delta
+        patch_nucmer_delta -d "~{delta}" "~{reference}" "~{query}" > patched.delta
+
+        nucmer_to_vcf "~{reference}" "~{query}" "patched.delta" \
+            | bcftools sort \
+            | bcftools norm -f "~{reference}" - > "~{prefix}.full.vcf"
+
+        # Move long ALT sequences of large insertions to separate FASTA
+        move_large_insertions -a "~{prefix}.insertions.fasta" "~{prefix}.full.vcf" > "~{prefix}.vcf"
+    >>>
+
+    #########################
+    RuntimeAttr default_attr = object {
+        cpu_cores:          1,
+        mem_gb:             8,
+        disk_gb:            10,
+        boot_disk_gb:       10,
+        preemptible_tries:  3,
+        max_retries:        1,
+        docker:             "us.gcr.io/broad-dsp-lrma/lr-variant-review:0.1.3"
+    }
+
+    RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
+
+    runtime {
+        cpu:                    select_first([runtime_attr.cpu_cores,         default_attr.cpu_cores])
+        memory:                 select_first([runtime_attr.mem_gb,            default_attr.mem_gb]) + " GiB"
+        disks: "local-disk " +  select_first([runtime_attr.disk_gb,           default_attr.disk_gb]) + " HDD"
+        bootDiskSizeGb:         select_first([runtime_attr.boot_disk_gb,      default_attr.boot_disk_gb])
+        preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
+        maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])
+        docker:                 select_first([runtime_attr.docker,            default_attr.docker])
     }
 }
+
+
+task CallVariantsMinimap2 {
+    input {
+        File reference
+        File query
+
+        String prefix
+
+        RuntimeAttr? runtime_attr_override
+    }
+
+    output {
+        File vcf = "~{prefix}.vcf"
+    }
+    
+    command <<<
+        set -euxo pipefail
+
+        minimap2 -cx asm5 --cs "~{reference}" "~{query}" \
+            | sort -k6,6 -k8,8n \
+            | paftools.js call -f "~{reference}" - > "~{prefix}.vcf"
+    >>>
+
+    #########################
+    RuntimeAttr default_attr = object {
+        cpu_cores:          1,
+        mem_gb:             8,
+        disk_gb:            10,
+        boot_disk_gb:       10,
+        preemptible_tries:  3,
+        max_retries:        1,
+        docker:             "us.gcr.io/broad-dsp-lrma/lr-variant-review:0.1.3"
+    }
+
+    RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
+
+    runtime {
+        cpu:                    select_first([runtime_attr.cpu_cores,         default_attr.cpu_cores])
+        memory:                 select_first([runtime_attr.mem_gb,            default_attr.mem_gb]) + " GiB"
+        disks: "local-disk " +  select_first([runtime_attr.disk_gb,           default_attr.disk_gb]) + " HDD"
+        bootDiskSizeGb:         select_first([runtime_attr.boot_disk_gb,      default_attr.boot_disk_gb])
+        preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
+        maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])
+        docker:                 select_first([runtime_attr.docker,            default_attr.docker])
+    }
+}
+
+task MergeVcfs {
+    input {
+        File vcf1
+        File vcf2
+
+        String prefix
+
+        RuntimeAttr? runtime_attr_override
+    }
+
+    output {
+        File bcf = "~{prefix}.vcf.gz"
+        File tbi = "~{prefix}.vcf.gz.tbi"
+    }
+
+    command <<<
+        set -euxo pipefail
+
+        bgzip "~{vcf1}"
+        bgzip "~{vcf2}"
+
+        tabix -p vcf "~{vcf1}.gz"
+        tabix -p vcf "~{vcf2}.gz"
+
+        # Somehow -O b doesn't work with tabix?
+        bcftools merge "~{vcf1}.gz" "~{vcf2}.gz" -O v > "~{prefix}.vcf"
+        bgzip "~{prefix}.vcf"
+        tabix "~{prefix}.vcf.gz"
+    >>>
+
+    #########################
+    RuntimeAttr default_attr = object {
+        cpu_cores:          1,
+        mem_gb:             8,
+        disk_gb:            10,
+        boot_disk_gb:       10,
+        preemptible_tries:  3,
+        max_retries:        1,
+        docker:             "us.gcr.io/broad-dsp-lrma/lr-variant-review:0.1.3"
+    }
+
+    RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
+
+    runtime {
+        cpu:                    select_first([runtime_attr.cpu_cores,         default_attr.cpu_cores])
+        memory:                 select_first([runtime_attr.mem_gb,            default_attr.mem_gb]) + " GiB"
+        disks: "local-disk " +  select_first([runtime_attr.disk_gb,           default_attr.disk_gb]) + " HDD"
+        bootDiskSizeGb:         select_first([runtime_attr.boot_disk_gb,      default_attr.boot_disk_gb])
+        preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
+        maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])
+        docker:                 select_first([runtime_attr.docker,            default_attr.docker])
+    }
+}
+
+
+task SVPlots {
+    input {
+        File reference
+        File query
+        File delta
+        File vcf
+
+        Array[File] bams
+        Array[File] bais
+        Array[String] names
+
+        RuntimeAttr? runtime_attr_override
+    }
+
+
+    output {
+        Array[File] plots = glob("*.png")
+    }
+
+    command <<<
+        patch_nucmer_delta -d "~{delta}" "~{reference}" "~{query}" > patched.delta
+
+        plot_sv_loci -r "~{reference}" -q "~{query}" -d "patched.delta" \
+            -V "~{vcf}" -b ~{sep=" " bams} -n ~{sep=" " names} -o .
+    >>>
+        
+    #########################
+    RuntimeAttr default_attr = object {
+        cpu_cores:          1,
+        mem_gb:             8,
+        disk_gb:            10,
+        boot_disk_gb:       10,
+        preemptible_tries:  3,
+        max_retries:        1,
+        docker:             "us.gcr.io/broad-dsp-lrma/lr-variant-review:0.1.3"
+    }
+
+    RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
+
+    runtime {
+        cpu:                    select_first([runtime_attr.cpu_cores,         default_attr.cpu_cores])
+        memory:                 select_first([runtime_attr.mem_gb,            default_attr.mem_gb]) + " GiB"
+        disks: "local-disk " +  select_first([runtime_attr.disk_gb,           default_attr.disk_gb]) + " HDD"
+        bootDiskSizeGb:         select_first([runtime_attr.boot_disk_gb,      default_attr.boot_disk_gb])
+        preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
+        maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])
+        docker:                 select_first([runtime_attr.docker,            default_attr.docker])
+    }
+}
+

--- a/wdl/tasks/AlignReads.wdl
+++ b/wdl/tasks/AlignReads.wdl
@@ -8,7 +8,7 @@ task Minimap2 {
         Array[File] reads
         File ref_fasta
 
-        String RG
+        String? RG
         String map_preset
 
         String prefix = "out"
@@ -28,10 +28,11 @@ task Minimap2 {
     Int cpus = 4
     Int mem = 30
 
+
     command <<<
         set -euxo pipefail
 
-        MAP_PARAMS="-ayYL --MD -x ~{map_preset} -R ~{RG} -t ~{cpus} ~{ref_fasta}"
+        MAP_PARAMS="-aYL --MD -x ~{map_preset} ~{if defined(RG) then "-RG ~{RG}" else ""} -t ~{cpus} ~{ref_fasta}"
         SORT_PARAMS="-@~{cpus} -m~{mem}G --no-PG -o ~{prefix}.bam"
         FILE="~{reads[0]}"
 

--- a/wdl/tasks/BWA.wdl
+++ b/wdl/tasks/BWA.wdl
@@ -1,0 +1,69 @@
+version 1.0
+
+import "Structs.wdl"
+
+task BWAMem2Align {
+    input {
+        File ref
+        Array[File]+ reads
+        String output_prefix
+
+        File? ref_0123 = ref + ".0123"
+        File? ref_amb = ref + ".amb"
+        File? ref_ann = ref + ".ann"
+        File? ref_bwt = ref + ".bwt.2bit.64"
+        File? ref_pac = ref + ".pac"
+
+        Boolean? keep_unaligned = false
+
+        RuntimeAttr? runtime_attr_override
+    }
+
+    output {
+        File aligned_bam = "~{output_prefix}.bam"
+        File aligned_bai = "~{output_prefix}.bam.bai"
+    }
+
+    command <<<
+        set -euxo pipefail
+
+        if [[ ! -f "~{ref_0123}" || ! -f "~{ref_amb}" || -f "~{ref_ann}" || ! -f "~{ref_bwt}" || ! -f "~{ref_pac}" ]]; then
+            bwa-mem2 index "~{ref}"
+        fi
+
+        if [[ "~{true="1" false="0" keep_unaligned}" == "0" ]]; then
+            bwa-mem2 mem -t ~{runtime_attr.cpu_cores} "~{ref}" ~{sep=' ' reads} \
+                | samtools view -h -F 4 \
+                | samtools sort -@ ~{runtime_attr.cpu_cores} -O bam -o "~{output_prefix}.bam"
+        else
+            bwa-mem2 mem -t ~{runtime_attr.cpu_cores} "~{ref}" ~{sep=' ' reads} \
+                | samtools sort -@ ~{runtime_attr.cpu_cores} -O bam -o "~{output_prefix}.bam"
+        fi
+
+        samtools index "~{output_prefix}.bam"
+    >>>
+
+
+    #########################
+    RuntimeAttr default_attr = object {
+        cpu_cores:          4,
+        mem_gb:             16,
+        disk_gb:            20,
+        boot_disk_gb:       10,
+        preemptible_tries:  3,
+        max_retries:        1,
+        docker:             "us.gcr.io/broad-dsp-lrma/lr-bwa-mem2:2.2.1"
+    }
+    RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
+
+    runtime {
+        cpu:                    select_first([runtime_attr.cpu_cores,         default_attr.cpu_cores])
+        memory:                 select_first([runtime_attr.mem_gb,            default_attr.mem_gb]) + " GiB"
+        disks: "local-disk " +  select_first([runtime_attr.disk_gb,           default_attr.disk_gb]) + " HDD"
+        bootDiskSizeGb:         select_first([runtime_attr.boot_disk_gb,      default_attr.boot_disk_gb])
+        preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
+        maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])
+        docker:                 select_first([runtime_attr.docker,            default_attr.docker])
+    }
+}
+

--- a/wdl/tasks/WGA.wdl
+++ b/wdl/tasks/WGA.wdl
@@ -10,7 +10,7 @@ task Minimap2 {
 
         String prefix
 
-        String? preset = "asm5"
+        String? map_preset = "asm5"
         RuntimeAttr? runtime_attr_override
     }
 
@@ -20,7 +20,7 @@ task Minimap2 {
     }
 
     command <<<
-        minimap2 -ax ~{prefix} -t ~{runtime_attr.cpu_cores} "~{ref1}" "~{ref2}" \
+        minimap2 -ax ~{map_preset} -t ~{runtime_attr.cpu_cores} "~{ref1}" "~{ref2}" \
             | samtools sort -@ ~{runtime_attr.cpu_cores} -O bam -o "~{prefix}.bam"
 
         samtools index "~{prefix}.bam"
@@ -76,7 +76,7 @@ task Nucmer {
         set -euxo pipefail
 
         nucmer "~{ref1}" "~{ref2}" -p "~{prefix}"
-        delta-filter -q "~{prefix}.delta" > "~{filtered_delta}"
+        delta-filter -q "~{prefix}.delta" > "~{prefix}.filtered.delta"
     >>>
 
     #########################

--- a/wdl/tasks/WGA.wdl
+++ b/wdl/tasks/WGA.wdl
@@ -1,0 +1,103 @@
+version 1.0
+
+import "Structs.wdl"
+
+
+task Minimap2 {
+    input {
+        File ref1
+        File ref2
+
+        String prefix
+
+        String? preset = "asm5"
+        RuntimeAttr? runtime_attr_override
+    }
+
+    output {
+        File wga_bam = "~{prefix}.bam"
+        File wga_bai = "~{prefix}.bam.bai"
+    }
+
+    command <<<
+        minimap2 -ax ~{prefix} -t ~{runtime_attr.cpu_cores} "~{ref1}" "~{ref2}" \
+            | samtools sort -@ ~{runtime_attr.cpu_cores} -O bam -o "~{prefix}.bam"
+
+        samtools index "~{prefix}.bam"
+    >>>
+
+    #########################
+    RuntimeAttr default_attr = object {
+        cpu_cores:          1,
+        mem_gb:             8,
+        disk_gb:            10,
+        boot_disk_gb:       10,
+        preemptible_tries:  3,
+        max_retries:        1,
+        docker:             "us.gcr.io/broad-dsp-lrma/lr-wga:0.1.0"
+    }
+
+    RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
+
+    runtime {
+        cpu:                    select_first([runtime_attr.cpu_cores,         default_attr.cpu_cores])
+        memory:                 select_first([runtime_attr.mem_gb,            default_attr.mem_gb]) + " GiB"
+        disks: "local-disk " +  select_first([runtime_attr.disk_gb,           default_attr.disk_gb]) + " HDD"
+        bootDiskSizeGb:         select_first([runtime_attr.boot_disk_gb,      default_attr.boot_disk_gb])
+        preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
+        maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])
+        docker:                 select_first([runtime_attr.docker,            default_attr.docker])
+    }
+}
+
+
+task Nucmer {
+    input {
+        File ref1
+        File ref2
+
+        String prefix
+        RuntimeAttr? runtime_attr_override
+    }
+
+    parameter_meta {
+        ref1: "Reference genome FASTA (has to be uncompressed)"
+        ref2: "Query genome FASTA (has to be uncompressed)"
+
+        prefix: "Output prefix. This task produces the original delta and a filtered file"
+    }
+
+    output {
+        File delta = "~{prefix}.delta"
+        File filtered_delta = "~{prefix}.filtered.delta"
+    }
+
+    command <<<
+        set -euxo pipefail
+
+        nucmer "~{ref1}" "~{ref2}" -p "~{prefix}"
+        delta-filter -q "~{prefix}.delta" > "~{filtered_delta}"
+    >>>
+
+    #########################
+    RuntimeAttr default_attr = object {
+        cpu_cores:          1,
+        mem_gb:             8,
+        disk_gb:            10,
+        boot_disk_gb:       10,
+        preemptible_tries:  3,
+        max_retries:        1,
+        docker:             "us.gcr.io/broad-dsp-lrma/lr-wga:0.1.0"
+    }
+    RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
+
+    runtime {
+        cpu:                    select_first([runtime_attr.cpu_cores,         default_attr.cpu_cores])
+        memory:                 select_first([runtime_attr.mem_gb,            default_attr.mem_gb]) + " GiB"
+        disks: "local-disk " +  select_first([runtime_attr.disk_gb,           default_attr.disk_gb]) + " HDD"
+        bootDiskSizeGb:         select_first([runtime_attr.boot_disk_gb,      default_attr.boot_disk_gb])
+        preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
+        maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])
+        docker:                 select_first([runtime_attr.docker,            default_attr.docker])
+    }
+}


### PR DESCRIPTION
This pull requests adds a WDL pipeline and required WDL tasks to review a large number of variants. 

Candidate variants are called by comparing two high quality references, using Nucmer and minimap2 and [SVrefine](https://github.com/nhansen/SVanalyzer). All reads are aligned to both assemblies, which in turn are used to generate reports to review all candidate variants.

Related repository: https://github.com/broadinstitute/bacterial_variant_truthset

- [x] Read alignments, Illumina/Nanopore/Pacbio
- [x] Task for generating candidate variants
- [ ] Task for generating reports 