### PR TITLE
Fix Longshot error

### DIFF
--- a/wdl/tasks/Longshot.wdl
+++ b/wdl/tasks/Longshot.wdl
@@ -25,7 +25,7 @@ task Longshot {
     String prefix = basename(bam, ".bam")
 
     command <<<
-        set -euxo pipefail
+        set -x
 
         num_core=$(cat /proc/cpuinfo | awk '/^processor/{print $3}' | wc -l)
         SM=$(samtools view -H ~{bam} | grep -m1 '^@RG' | sed 's/\t/\n/g' | grep '^SM:' | sed 's/SM://g')


### PR DESCRIPTION
Fix a Longshot failure caused by a silly pipe-related bug.