### PR TITLE
update Utils.ListFilesOfType to be more resilient to auth errors

### DIFF
--- a/wdl/tasks/Utils.wdl
+++ b/wdl/tasks/Utils.wdl
@@ -1479,19 +1479,10 @@ task ListFilesOfType {
     String in_dir = sub(gcs_dir, "/$", "")
 
     command <<<
-        set -x
-
-        RET=0
-
-        while read s; do
-            gsutil ls ~{in_dir}/**$s >> files.txt
-        done <~{write_lines(suffixes)}
-
-        if [[ $(wc -l files.txt) -eq 0 ]]; then
-            RET=1
-        fi
-
-        exit $RET
+        set -ex
+        gsutil ls ~{in_dir} > temp.txt
+        grep -E '(~{sep="|" suffixes})$' temp.txt > files.txt || touch files.txt
+        if [ ! -s files.txt ]; then echo "None found" && exit 1; fi
     >>>
 
     output {


### PR DESCRIPTION
Otherwise, a tricky bug creeps in:

given that we currently only `set -x`, so the auth errors will fail, yet files will still be de-localized.
Downstream tasks, which depends on this, will complain that nothing is available.
And re-runs with cach-enabled will copy over the empty files from the silent failures.....