### PR TITLE
faster BAM merging step: local SSD, 2 more threads, and

### DIFF
--- a/wdl/tasks/Utils.wdl
+++ b/wdl/tasks/Utils.wdl
@@ -961,8 +961,12 @@ task MergeBams {
     command <<<
         set -euxo pipefail
 
-        samtools merge -p -c -@2 --no-PG ~{prefix}.bam ~{sep=" " bams}
-        samtools index ~{prefix}.bam
+        samtools merge \
+            -p -c --no-PG \
+            -@ 2 \
+            --write-index \
+            -o "~{prefix}.bam##idx##~{prefix}.bam.bai"
+            ~{sep=" " bams}
     >>>
 
     output {
@@ -972,19 +976,19 @@ task MergeBams {
 
     #########################
     RuntimeAttr default_attr = object {
-        cpu_cores:          2,
+        cpu_cores:          4,
         mem_gb:             20,
         disk_gb:            disk_size,
         boot_disk_gb:       10,
         preemptible_tries:  0,
         max_retries:        0,
-        docker:             "us.gcr.io/broad-dsp-lrma/lr-utils:0.1.8"
+        docker:             "us.gcr.io/broad-dsp-lrma/lr-utils:0.1.10"
     }
     RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
     runtime {
         cpu:                    select_first([runtime_attr.cpu_cores,         default_attr.cpu_cores])
         memory:                 select_first([runtime_attr.mem_gb,            default_attr.mem_gb]) + " GiB"
-        disks: "local-disk " +  select_first([runtime_attr.disk_gb,           default_attr.disk_gb]) + " HDD"
+        disks: "local-disk " +  select_first([runtime_attr.disk_gb,           default_attr.disk_gb]) + " LOCAL"
         bootDiskSizeGb:         select_first([runtime_attr.boot_disk_gb,      default_attr.boot_disk_gb])
         preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
         maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])


### PR DESCRIPTION
concurrent idx creation

Otherwise the merging step takes 2x the amount of time of the alignment step.