### PR TITLE
Bring in phased VCF from DV-Pepper for CCS data

### DIFF
--- a/wdl/PBCCSWholeGenome.wdl
+++ b/wdl/PBCCSWholeGenome.wdl
@@ -138,6 +138,8 @@ workflow PBCCSWholeGenome {
             call FF.FinalizeToFile as FinalizeDVPepperTbi { input: outdir = smalldir, file = select_first([CallVariants.dvp_tbi])}
             call FF.FinalizeToFile as FinalizeDVPepperGVcf { input: outdir = smalldir, file = select_first([CallVariants.dvp_g_vcf])}
             call FF.FinalizeToFile as FinalizeDVPepperGTbi { input: outdir = smalldir, file = select_first([CallVariants.dvp_g_tbi])}
+            call FF.FinalizeToFile as FinalizeDVPEPPERPhasedVcf { input: outdir = smalldir, file = select_first([CallVariants.dvp_phased_vcf]), name = "~{participant_name}.deepvariant_pepper.phased.vcf.gz" }
+            call FF.FinalizeToFile as FinalizeDVPEPPERPhasedTbi { input: outdir = smalldir, file = select_first([CallVariants.dvp_phased_tbi]), name = "~{participant_name}.deepvariant_pepper.phased.vcf.gz.tbi" }
         }
     }
 
@@ -171,6 +173,8 @@ workflow PBCCSWholeGenome {
         File? dvp_tbi = FinalizeDVPepperTbi.gcs_path
         File? dvp_g_vcf = FinalizeDVPepperGVcf.gcs_path
         File? dvp_g_tbi = FinalizeDVPepperGTbi.gcs_path
+        File? dvp_phased_vcf = FinalizeDVPEPPERPhasedVcf.gcs_path
+        File? dvp_phased_tbi = FinalizeDVPEPPERPhasedTbi.gcs_path
 
         File? bed_cov_summary = FinalizeRegionalCoverage.gcs_path
 

--- a/wdl/tasks/CallVariantsPBCCS.wdl
+++ b/wdl/tasks/CallVariantsPBCCS.wdl
@@ -162,6 +162,17 @@ workflow CallVariants {
                 bams = CCSPepper.hap_tagged_bam,
                 prefix = prefix +  ".MARGIN_PHASED.PEPPER_SNP_MARGIN.haplotagged"
         }
+
+        call CCSPepper.MarginPhase {
+            input:
+                bam           = bam,
+                bai           = bai,
+                unphased_vcf  = MergeDeepVariantVCFs.vcf,
+                unphased_vcf_tbi = MergeDeepVariantVCFs.tbi,
+                ref_fasta     = ref_fasta,
+                ref_fasta_fai = ref_fasta_fai,
+                memory        = select_first([dvp_memory, 64])
+        }
     }
 
     ######################################################################
@@ -273,5 +284,7 @@ workflow CallVariants {
         File? dvp_g_tbi = MergeDeepVariantGVCFs.tbi
         File? dvp_vcf = MergeDeepVariantVCFs.vcf
         File? dvp_tbi = MergeDeepVariantVCFs.tbi
+        File? dvp_phased_vcf = MarginPhase.phasedVCF
+        File? dvp_phased_tbi = MarginPhase.phasedtbi
     }
 }


### PR DESCRIPTION
Originally wasn't in during #268 due to time constraint.

Now available with help from the authors of the DV-Pepper pipeline.