### PR TITLE
drop unnecessary import of outdated DeepVariant.wdl

### DIFF
--- a/wdl/tasks/CallAssemblyVariants.wdl
+++ b/wdl/tasks/CallAssemblyVariants.wdl
@@ -3,7 +3,6 @@ version 1.0
 import "Structs.wdl"
 import "Utils.wdl" as Utils
 import "Longshot.wdl" as Longshot
-import "DeepVariant.wdl" as DV
 
 workflow CallAssemblyVariants {
     input {


### PR DESCRIPTION
this caused several workflows fail to validate

closes #274 