### PR TITLE
Optionally override LB (library) entry in aligning PacBio reads

### DIFF
--- a/wdl/PBFlowcell.wdl
+++ b/wdl/PBFlowcell.wdl
@@ -20,6 +20,7 @@ workflow PBFlowcell {
         File ref_map_file
 
         String SM
+        String LB
 
         Boolean drop_per_base_N_pulse_tags = true
 
@@ -36,6 +37,7 @@ workflow PBFlowcell {
         ref_map_file:       "table indicating reference sequence and auxillary file locations"
 
         SM:                 "the value to place in the BAM read group's SM field"
+        LB:                 "the value to place in the BAM read group's LB (library) field"
 
         num_shards:         "[default-valued] number of shards into which fastq files should be batched"
         experiment_type:    "type of experiment run (CLR, CCS, ISOSEQ, MASSEQ)"
@@ -74,6 +76,7 @@ workflow PBFlowcell {
                 bam         = unaligned_bam,
                 ref_fasta   = ref_map['fasta'],
                 sample_name = SM,
+                library     = LB,
                 map_preset  = map_presets[experiment_type],
                 drop_per_base_N_pulse_tags = drop_per_base_N_pulse_tags
         }


### PR DESCRIPTION
This is to a **partial** fix to #286 .

Importantly, this does not fix the input BAM (we probably should not, as I give it more thoughts).
Nor does this fix unaligned CCS bam if the input is CCS reads:

https://github.com/broadinstitute/long-read-pipelines/blob/a4384911c989b81efe23272a42e32ba970670372/wdl/PBFlowcell.wdl#L67

https://github.com/broadinstitute/long-read-pipelines/blob/a4384911c989b81efe23272a42e32ba970670372/wdl/PBFlowcell.wdl#L92

That will be fixed in a separate PR.