### PR TITLE
Update PBFlowcell workflow

### DIFF
--- a/wdl/PBFlowcell.wdl
+++ b/wdl/PBFlowcell.wdl
@@ -20,6 +20,7 @@ workflow PBFlowcell {
         File ref_map_file
 
         String SM
+        String LB
 
         Boolean drop_per_base_N_pulse_tags = true
 
@@ -36,6 +37,7 @@ workflow PBFlowcell {
         ref_map_file:       "table indicating reference sequence and auxillary file locations"
 
         SM:                 "the value to place in the BAM read group's SM field"
+        LB:                 "the value to place in the BAM read group's LB (library) field"
 
         num_shards:         "[default-valued] number of shards into which fastq files should be batched"
         experiment_type:    "type of experiment run (CLR, CCS, ISOSEQ, MASSEQ)"
@@ -74,6 +76,7 @@ workflow PBFlowcell {
                 bam         = unaligned_bam,
                 ref_fasta   = ref_map['fasta'],
                 sample_name = SM,
+                library     = LB,
                 map_preset  = map_presets[experiment_type],
                 drop_per_base_N_pulse_tags = drop_per_base_N_pulse_tags
         }

--- a/wdl/PBFlowcell.wdl
+++ b/wdl/PBFlowcell.wdl
@@ -66,7 +66,12 @@ workflow PBFlowcell {
     scatter (unmapped_shard in ShardLongReads.unmapped_shards) {
         if (experiment_type != "CLR") {
             if (!GetRunInfo.is_corrected) { call PB.CCS { input: subreads = unmapped_shard } }
-            call PB.ExtractHifiReads { input: bam = select_first([CCS.consensus, unmapped_shard]) }
+            call PB.ExtractHifiReads {
+                input:
+                    bam = select_first([CCS.consensus, unmapped_shard]),
+                    sample_name = SM,
+                    library     = LB
+            }
         }
 
         File unaligned_bam = select_first([ExtractHifiReads.hifi_bam, unmapped_shard])

--- a/wdl/tasks/PBUtils.wdl
+++ b/wdl/tasks/PBUtils.wdl
@@ -138,7 +138,7 @@ task ShardLongReads {
     runtime {
         cpu:                    select_first([runtime_attr.cpu_cores,         default_attr.cpu_cores])
         memory:                 select_first([runtime_attr.mem_gb,            default_attr.mem_gb]) + " GiB"
-        disks: "local-disk " +  select_first([runtime_attr.disk_gb,           default_attr.disk_gb]) + " HDD"
+        disks: "local-disk " +  select_first([runtime_attr.disk_gb,           default_attr.disk_gb]) + " LOCAL"
         bootDiskSizeGb:         select_first([runtime_attr.boot_disk_gb,      default_attr.boot_disk_gb])
         preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
         maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])

--- a/wdl/tasks/Utils.wdl
+++ b/wdl/tasks/Utils.wdl
@@ -934,7 +934,7 @@ task MergeFastqGzs {
     runtime {
         cpu:                    select_first([runtime_attr.cpu_cores,         default_attr.cpu_cores])
         memory:                 select_first([runtime_attr.mem_gb,            default_attr.mem_gb]) + " GiB"
-        disks: "local-disk " +  select_first([runtime_attr.disk_gb,           default_attr.disk_gb]) + " HDD"
+        disks: "local-disk " +  select_first([runtime_attr.disk_gb,           default_attr.disk_gb]) + " LOCAL"
         bootDiskSizeGb:         select_first([runtime_attr.boot_disk_gb,      default_attr.boot_disk_gb])
         preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
         maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])


### PR DESCRIPTION
Separated into three commits, the first to are literrally `cherry-picked` from #288 and #287 .

With the last commit, this closes #286 via the updated `PBFlowcell` workflow.

It works this way: if metadata related to sample id (e.g. bio sample, well sample, collaborator participant id) were given the wrong value at sequencing time (unfortunately), we can simply (re-)run the `PBFlowcell` workflow by correcting the two inputs `SM` and `LB`. 