### PR TITLE
new notebook for checking FTP-2-GCS data-download consistency

### DIFF
--- a/notebooks/misc/check_data_consistency_ftp_gcs.ipynb
+++ b/notebooks/misc/check_data_consistency_ftp_gcs.ipynb
@@ -1,0 +1,1412 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import re\n",
+    "\n",
+    "from typing import List\n",
+    "\n",
+    "import google.cloud.client\n",
+    "\n",
+    "from google.cloud import storage\n",
+    "dev_storage_client = storage.Client()\n",
+    "\n",
+    "import ftplib"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "outputs": [],
+   "source": [
+    "import pprint\n",
+    "pp = pprint.PrettyPrinter(indent=4)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# Overall \"environment\" variables"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "outputs": [],
+   "source": [
+    "aria2_flags = '--check-integrity --continue --max-tries=0'"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "outputs": [],
+   "source": [
+    "ftp_site = 'ftp.1000genomes.ebi.ac.uk'\n",
+    "\n",
+    "ftp_data_root = '/vol1/ftp/data_collections/HGSVC2/working'"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "outputs": [],
+   "source": [
+    "gcs_bucket_name = \"broad-dsde-methods-long-reads\"\n",
+    "gcs_root_prefix = 'datasets/HGSVC2'"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "outputs": [],
+   "source": [
+    "gcsfuse_local_dir = 'gs'\n",
+    "gcs_leading_prefix = f'gs://{gcs_bucket_name}/{gcs_root_prefix}'.rstrip('/') + '/'\n",
+    "gcsfuse_local_leading_prefix = f'{gcsfuse_local_dir}/{gcs_root_prefix}'.rstrip('/') + '/'"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "outputs": [],
+   "source": [
+    "gcs_dirs = ['20190925_PUR_PacBio_HiFi',\n",
+    "            '20191005_YRI_PacBio_NA19240_HiFi',\n",
+    "            '20191031_CHS_PacBio_HG00512_HiFi',\n",
+    "            '20191031_CHS_PacBio_HG00513_HiFi',\n",
+    "            '20191205_YRI_PacBio_NA19238_HIFI',\n",
+    "            '20191205_YRI_PacBio_NA19239_HIFI',\n",
+    "            '20200108_PacBio_CLR_JAX',\n",
+    "            '20200203_PacBio_CLR_EEE',\n",
+    "            '20200212_PacBio_CLR_Devine',\n",
+    "            '20200722_PUR_PacBio_HG00732_HiFi',\n",
+    "            '20200731_CHS_PacBio_HG00514_CLR_reseq',\n",
+    "            '20200731_CHS_PacBio_HG00514_HiFi_reseq',\n",
+    "            '20210509_UW_HiFi',\n",
+    "            '2021_PacBio_HIFI_JAX'\n",
+    "            ]"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "outputs": [],
+   "source": [
+    "known_data_directories_on_ftp = ['20190925_PUR_PacBio_HiFi/',\n",
+    "                                 '20191005_YRI_PacBio_NA19240_HiFi/',\n",
+    "                                 '20191031_CHS_PacBio_HG00512_HiFi/',\n",
+    "                                 '20191031_CHS_PacBio_HG00513_HiFi/',\n",
+    "                                 '20191205_YRI_PacBio_NA19238_HIFI/',\n",
+    "                                 '20191205_YRI_PacBio_NA19239_HIFI/',\n",
+    "                                 '20200108_PacBio_CLR_JAX/',\n",
+    "                                 '20200203_PacBio_CLR_EEE/',\n",
+    "                                 '20200212_PacBio_CLR_Devine/',\n",
+    "                                 '20200722_PUR_PacBio_HG00732_HiFi/',\n",
+    "                                 '20200731_CHS_PacBio_HG00514_CLR_reseq/',\n",
+    "                                 '20200731_CHS_PacBio_HG00514_HiFi_reseq/',\n",
+    "                                 '20210509_UW_HiFi/',\n",
+    "                                 '20210822_UW_EEE_ONT_UL/',\n",
+    "                                 '20210920_ONT_Rebasecalled/',\n",
+    "                                 '20211013_ONT_Rebasecalled/',\n",
+    "                                 '2021_ONT_UltraLong_JAX/',\n",
+    "                                 '2021_PacBio_HIFI_JAX/'\n",
+    "                                 ]"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "outputs": [],
+   "source": [],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "outputs": [],
+   "source": [
+    "test_dir = gcs_dirs[0]"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "outputs": [],
+   "source": [],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# Utilities for exploring FTP site"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "outputs": [],
+   "source": [
+    "def traverse_ftp_data_dir(configured_ftp: ftplib.FTP, working_dir: str, depth: int=0):\n",
+    "    \"\"\"\n",
+    "    Return a recursive listing of an ftp server contents, under the current directory.\n",
+    "\n",
+    "    :param configured_ftp: ftplib.FTP object with the intended directory to explore\n",
+    "    :param working_dir: current directory being explored\n",
+    "    :param depth: depth into the origin dir\n",
+    "    :return: a recursive dictionary, where\n",
+    "                each key is the name of an entity (a file or a sub-directory), and\n",
+    "                its value is its size in bytes in case of a file, or\n",
+    "                its contents (a dict) in case of a sub-directory.\n",
+    "    \"\"\"\n",
+    "\n",
+    "    if depth > 10:\n",
+    "        raise ValueError(\"Tree is too deep, I give up.\")\n",
+    "    level = {}\n",
+    "    contents = []\n",
+    "    configured_ftp.cwd(working_dir)\n",
+    "    configured_ftp.retrlines('LIST', callback=lambda s: contents.append(s.split()))\n",
+    "    for entry in contents:\n",
+    "        mode = entry[0]\n",
+    "        name = entry[-1]\n",
+    "        if mode.startswith('d'):  # it's a sub-dir (note this is a hack, check this out: https://bit.ly/31zQWLS)\n",
+    "            level[name] = traverse_ftp_data_dir(configured_ftp, name, depth+1)\n",
+    "            configured_ftp.cwd('..')\n",
+    "        else:  # it's a regular file\n",
+    "            level[name] = configured_ftp.size(name)\n",
+    "    return level\n",
+    "\n",
+    "def flatten_ftp_dir_tree(nested_dict_tree: dict,\n",
+    "                         configured_ftp: ftplib.FTP,\n",
+    "                         data_dir: str):\n",
+    "    \"\"\"\n",
+    "    Given the nested dir returned by `traverse_ftp_data_dir`, flatten it to a 1-D\n",
+    "    dict where the key is the path to a file, and value is its size in bytes.\n",
+    "\n",
+    "    :param nested_dict_tree: the structure returned by `traverse_ftp_data_dir`\n",
+    "    :param configured_ftp: a ftplib.FTP object where the nested dir was generated on\n",
+    "    :param data_dir: the origin dir where `traverse_ftp_data_dir` was run on\n",
+    "    :return: A list where the entries are absolute paths to each individual file\n",
+    "    \"\"\"\n",
+    "    flat_file_list = dict()\n",
+    "    for k, v in nested_dict_tree.items():\n",
+    "        if isinstance(v, dict):\n",
+    "            child = flatten_ftp_dir_tree(nested_dict_tree.get(k), configured_ftp = configured_ftp,\n",
+    "                                         data_dir = f'{data_dir}/{k}')\n",
+    "            flat_file_list.update(child)\n",
+    "        else:\n",
+    "            name = f'{configured_ftp.host}{ftp_data_root}/{data_dir}/{k}'\n",
+    "            flat_file_list[name] = v\n",
+    "    return flat_file_list"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "#### Test"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exploring /vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi\n"
+     ]
+    }
+   ],
+   "source": [
+    "with (ftplib.FTP(ftp_site)) as ftp_socket:\n",
+    "    ftp_socket.login()\n",
+    "    to_explore = ftp_data_root + '/' + test_dir\n",
+    "    print(f\"Exploring {to_explore}\")\n",
+    "    test_tree = traverse_ftp_data_dir(ftp_socket, working_dir=to_explore)\n",
+    "    test_flat = flatten_ftp_dir_tree(test_tree, ftp_socket, test_dir)\n",
+    "    ftp_socket.quit()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{   'HG00731_20190925_EEE_m54329U_190528_231241.Q20.fastq.gz': 15898357143,\n",
+      "    'HG00731_20190925_EEE_m54329U_190528_231241.ccs.bam': 16360367615,\n",
+      "    'HG00731_20190925_EEE_m54329U_190528_231241.ccs.bam.bai': 16,\n",
+      "    'HG00731_20190925_EEE_m54329U_190528_231241.ccs.bam.pbi': 18776409,\n",
+      "    'HG00731_20190925_EEE_m54329U_190531_175004.Q20.fastq.gz': 17040893093,\n",
+      "    'HG00731_20190925_EEE_m54329U_190531_175004.ccs.bam': 17552770586,\n",
+      "    'HG00731_20190925_EEE_m54329U_190531_175004.ccs.bam.bai': 16,\n",
+      "    'HG00731_20190925_EEE_m54329U_190531_175004.ccs.bam.pbi': 20713931,\n",
+      "    'HG00731_20190925_EEE_m54329U_190601_235636.Q20.fastq.gz': 16313818362,\n",
+      "    'HG00731_20190925_EEE_m54329U_190601_235636.ccs.bam': 16803785954,\n",
+      "    'HG00731_20190925_EEE_m54329U_190601_235636.ccs.bam.bai': 16,\n",
+      "    'HG00731_20190925_EEE_m54329U_190601_235636.ccs.bam.pbi': 19432762,\n",
+      "    'HG00731_20190925_EEE_m54329U_190606_045526.Q20.fastq.gz': 15568945475,\n",
+      "    'HG00731_20190925_EEE_m54329U_190606_045526.ccs.bam': 16037880166,\n",
+      "    'HG00731_20190925_EEE_m54329U_190606_045526.ccs.bam.bai': 16,\n",
+      "    'HG00731_20190925_EEE_m54329U_190606_045526.ccs.bam.pbi': 18826586,\n",
+      "    'HG00731_20190925_EEE_m54329U_190906_205127.Q20.fastq.gz': 16591637237,\n",
+      "    'HG00731_20190925_EEE_m54329U_190906_205127.ccs.bam': 16915283482,\n",
+      "    'HG00731_20190925_EEE_m54329U_190906_205127.ccs.bam.bai': 16,\n",
+      "    'HG00731_20190925_EEE_m54329U_190906_205127.ccs.bam.pbi': 12932993,\n",
+      "    'HG00733_20190925_EEE_m54329U_190607_185248.Q20.fastq.gz': 9972328039,\n",
+      "    'HG00733_20190925_EEE_m54329U_190607_185248.ccs.bam': 10242883632,\n",
+      "    'HG00733_20190925_EEE_m54329U_190607_185248.ccs.bam.bai': 16,\n",
+      "    'HG00733_20190925_EEE_m54329U_190607_185248.ccs.bam.pbi': 11468067,\n",
+      "    'HG00733_20190925_EEE_m54329U_190615_010947.Q20.fastq.gz': 9966703426,\n",
+      "    'HG00733_20190925_EEE_m54329U_190615_010947.ccs.bam': 10164219610,\n",
+      "    'HG00733_20190925_EEE_m54329U_190615_010947.ccs.bam.bai': 16,\n",
+      "    'HG00733_20190925_EEE_m54329U_190615_010947.ccs.bam.pbi': 9091441,\n",
+      "    'HG00733_20190925_EEE_m54329U_190617_231905.Q20.fastq.gz': 9486694384,\n",
+      "    'HG00733_20190925_EEE_m54329U_190617_231905.ccs.bam': 9673349287,\n",
+      "    'HG00733_20190925_EEE_m54329U_190617_231905.ccs.bam.bai': 16,\n",
+      "    'HG00733_20190925_EEE_m54329U_190617_231905.ccs.bam.pbi': 8653251,\n",
+      "    'HG00733_20190925_EEE_m54329U_190619_052546.Q20.fastq.gz': 7594807936,\n",
+      "    'HG00733_20190925_EEE_m54329U_190619_052546.ccs.bam': 7736626574,\n",
+      "    'HG00733_20190925_EEE_m54329U_190619_052546.ccs.bam.bai': 16,\n",
+      "    'HG00733_20190925_EEE_m54329U_190619_052546.ccs.bam.pbi': 6980576,\n",
+      "    'HG00733_20190925_EEE_m54329U_190629_180018.Q20.fastq.gz': 12603662064,\n",
+      "    'HG00733_20190925_EEE_m54329U_190629_180018.ccs.bam': 12879976979,\n",
+      "    'HG00733_20190925_EEE_m54329U_190629_180018.ccs.bam.bai': 16,\n",
+      "    'HG00733_20190925_EEE_m54329U_190629_180018.ccs.bam.pbi': 11740147,\n",
+      "    'HG00733_20190925_EEE_m54329U_190701_222759.Q20.fastq.gz': 13612951231,\n",
+      "    'HG00733_20190925_EEE_m54329U_190701_222759.ccs.bam': 13904584675,\n",
+      "    'HG00733_20190925_EEE_m54329U_190701_222759.ccs.bam.bai': 16,\n",
+      "    'HG00733_20190925_EEE_m54329U_190701_222759.ccs.bam.pbi': 12687615,\n",
+      "    'HG00733_20190925_EEE_m54329U_190827_173812.Q20.fastq.gz': 24059030269,\n",
+      "    'HG00733_20190925_EEE_m54329U_190827_173812.ccs.bam': 24367771175,\n",
+      "    'HG00733_20190925_EEE_m54329U_190827_173812.ccs.bam.bai': 16,\n",
+      "    'HG00733_20190925_EEE_m54329U_190827_173812.ccs.bam.pbi': 16891344,\n",
+      "    'LAMBDA_20190925_EEE_PUR_TRIO.tsv.gz': 1870,\n",
+      "    'MANIFEST_20190925_EEE_PUR_TRIO.txt': 7053,\n",
+      "    'README_20190925_EEE_PUR_TRIO.txt': 1697,\n",
+      "    'RUNSTATS_20190925_EEE_PUR_TRIO.tsv': 1970}\n"
+     ]
+    }
+   ],
+   "source": [
+    "pp.pprint(test_tree)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "{'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00731_20190925_EEE_m54329U_190528_231241.Q20.fastq.gz': 15898357143,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00731_20190925_EEE_m54329U_190528_231241.ccs.bam': 16360367615,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00731_20190925_EEE_m54329U_190528_231241.ccs.bam.bai': 16,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00731_20190925_EEE_m54329U_190528_231241.ccs.bam.pbi': 18776409,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00731_20190925_EEE_m54329U_190531_175004.Q20.fastq.gz': 17040893093,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00731_20190925_EEE_m54329U_190531_175004.ccs.bam': 17552770586,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00731_20190925_EEE_m54329U_190531_175004.ccs.bam.bai': 16,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00731_20190925_EEE_m54329U_190531_175004.ccs.bam.pbi': 20713931,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00731_20190925_EEE_m54329U_190601_235636.Q20.fastq.gz': 16313818362,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00731_20190925_EEE_m54329U_190601_235636.ccs.bam': 16803785954,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00731_20190925_EEE_m54329U_190601_235636.ccs.bam.bai': 16,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00731_20190925_EEE_m54329U_190601_235636.ccs.bam.pbi': 19432762,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00731_20190925_EEE_m54329U_190606_045526.Q20.fastq.gz': 15568945475,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00731_20190925_EEE_m54329U_190606_045526.ccs.bam': 16037880166,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00731_20190925_EEE_m54329U_190606_045526.ccs.bam.bai': 16,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00731_20190925_EEE_m54329U_190606_045526.ccs.bam.pbi': 18826586,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00731_20190925_EEE_m54329U_190906_205127.Q20.fastq.gz': 16591637237,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00731_20190925_EEE_m54329U_190906_205127.ccs.bam': 16915283482,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00731_20190925_EEE_m54329U_190906_205127.ccs.bam.bai': 16,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00731_20190925_EEE_m54329U_190906_205127.ccs.bam.pbi': 12932993,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190607_185248.Q20.fastq.gz': 9972328039,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190607_185248.ccs.bam': 10242883632,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190607_185248.ccs.bam.bai': 16,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190607_185248.ccs.bam.pbi': 11468067,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190615_010947.Q20.fastq.gz': 9966703426,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190615_010947.ccs.bam': 10164219610,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190615_010947.ccs.bam.bai': 16,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190615_010947.ccs.bam.pbi': 9091441,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190617_231905.Q20.fastq.gz': 9486694384,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190617_231905.ccs.bam': 9673349287,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190617_231905.ccs.bam.bai': 16,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190617_231905.ccs.bam.pbi': 8653251,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190619_052546.Q20.fastq.gz': 7594807936,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190619_052546.ccs.bam': 7736626574,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190619_052546.ccs.bam.bai': 16,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190619_052546.ccs.bam.pbi': 6980576,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190629_180018.Q20.fastq.gz': 12603662064,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190629_180018.ccs.bam': 12879976979,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190629_180018.ccs.bam.bai': 16,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190629_180018.ccs.bam.pbi': 11740147,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190701_222759.Q20.fastq.gz': 13612951231,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190701_222759.ccs.bam': 13904584675,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190701_222759.ccs.bam.bai': 16,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190701_222759.ccs.bam.pbi': 12687615,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190827_173812.Q20.fastq.gz': 24059030269,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190827_173812.ccs.bam': 24367771175,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190827_173812.ccs.bam.bai': 16,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190827_173812.ccs.bam.pbi': 16891344,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/LAMBDA_20190925_EEE_PUR_TRIO.tsv.gz': 1870,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/MANIFEST_20190925_EEE_PUR_TRIO.txt': 7053,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/README_20190925_EEE_PUR_TRIO.txt': 1697,\n 'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/RUNSTATS_20190925_EEE_PUR_TRIO.tsv': 1970}"
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "test_flat"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "outputs": [],
+   "source": [],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# Utilities for exploring GCS buckets and \"folders\""
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "outputs": [],
+   "source": [
+    "def list_gcs_subdirectories(client: google.cloud.client.Client, bucket_name: str, prefix: str):\n",
+    "    \"\"\"\n",
+    "    List sub-directories under 'gs://[bucket_name]/[prefix]/'\n",
+    "    Based on https://github.com/googleapis/google-cloud-python/issues/920#issuecomment-653823847\n",
+    "    :param client: GCS client\n",
+    "    :param bucket_name: name of the bucket\n",
+    "    :param prefix: the prefix, or the full path to the directory to list into. Note: don't include leading and ending slash.\n",
+    "    :return: A list of sub-directories under the prefix 'directory' in the provided bucket\n",
+    "    \"\"\"\n",
+    "\n",
+    "    local_prefix = prefix if prefix.endswith('/') else prefix + '/'\n",
+    "    iterator = client.list_blobs(bucket_name, prefix=local_prefix, delimiter='/')\n",
+    "    prefixes = set()\n",
+    "    for page in iterator.pages:\n",
+    "        prefixes.update(page.prefixes)\n",
+    "\n",
+    "    return list([s.split('/')[-2] for s in prefixes])"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "outputs": [],
+   "source": [
+    "def list_file_base_names(client: google.cloud.client.Client, bucket_name: str, prefix: str):\n",
+    "    \"\"\"\n",
+    "    Give base name of files under 'gs://[bucket_name]/[prefix]/'\n",
+    "    :param client: GCS client\n",
+    "    :param bucket_name: name of the bucket\n",
+    "    :param prefix: the prefix, or the full path to the directory to list into. Note: don't include leading and ending slash.\n",
+    "    :return: base name of files under the prefix 'directory' in the provided bucket\n",
+    "    \"\"\"\n",
+    "\n",
+    "    full_path = [b.name for b in client.list_blobs(bucket_or_name=bucket_name, prefix=prefix)]\n",
+    "    return [re.sub(f'^{prefix}', '', path).lstrip('/') for path in full_path]"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "outputs": [],
+   "source": [
+    "class GcsPath:\n",
+    "    \"\"\"\n",
+    "    Modeling after GCS storage object, offering simplistic way of\n",
+    "        * checking if the paths exists, and if exists,\n",
+    "        * represents a file or\n",
+    "        * emulates a 'directory'.\n",
+    "    \"\"\"\n",
+    "\n",
+    "    def __init__(self, gs_path: str):\n",
+    "\n",
+    "        if not gs_path.startswith(\"gs://\"):\n",
+    "            raise ValueError(f\"Provided gs path isn't valid: {gs_path}\")\n",
+    "\n",
+    "        arr = re.sub(\"^gs://\", '', gs_path).split('/')\n",
+    "        self.bucket = arr[0]\n",
+    "        self.prefix = '/'.join(arr[1:-1])\n",
+    "        self.file = arr[-1]\n",
+    "\n",
+    "    def exists(self, client: storage.client.Client) -> bool:\n",
+    "        return self.is_file(client=client) or self.is_emulate_dir(client=client)\n",
+    "\n",
+    "    def is_file(self, client: storage.client.Client) -> bool:\n",
+    "        return storage.Blob(bucket=client.bucket(self.bucket), name=f'{self.prefix}/{self.file}').exists(client)\n",
+    "\n",
+    "    def is_emulate_dir(self, client: storage.client.Client) -> bool:\n",
+    "        if self.is_file(client=client):\n",
+    "            return False\n",
+    "        return any(True for _ in client.list_blobs(client.bucket(self.bucket), prefix=f'{self.prefix}/{self.file}'))\n",
+    "\n",
+    "    def size(self, client: storage.client.Client) -> int:\n",
+    "        blob = storage.Blob(bucket=client.bucket(self.bucket), name=f'{self.prefix}/{self.file}')\n",
+    "        if blob.exists(client=client):\n",
+    "            blob.reload()\n",
+    "            return blob.size\n",
+    "        else:\n",
+    "            return 0"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# traverse each dir already on GCS, and check which ones are missing compared to its mirroring folder on FTP"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "outputs": [],
+   "source": [
+    "def collect_files_to_transfer(gcs_dir_to_check: str, gcs_client: google.cloud.storage.Client,\n",
+    "                              ftp_server: str, ftp_data_root_dir: str,\n",
+    "                              gcs_bucket_name: str, gcs_root_prefix: str):\n",
+    "\n",
+    "    \"\"\"\n",
+    "    Given a 'folder' on GCS to check data consistency (against a FTP folder), collect which files\n",
+    "       1) have been successfully downloaded,\n",
+    "       2) have been only partially downloaded,\n",
+    "       3) have not been downloaded at all\n",
+    "    The way this is checked is by using file sizes (a compromise compared to MD5 check).\n",
+    "    :param gcs_dir_to_check: 'folder' on GCS to check\n",
+    "    :param gcs_client: GCS python API client\n",
+    "    :param ftp_server: FTP server address\n",
+    "    :param ftp_data_root_dir: root dir holding data, which is supposed to be mirrored by gcs_dir_to_check\n",
+    "    :param gcs_bucket_name: GCS bucket hosting the dir\n",
+    "    :param gcs_root_prefix: root prefix, i.e. 'parent folder' of gcs_dir_to_check, under the hosting bucket\n",
+    "    :return: a tuple-3 of (fully downloaded, incompletely downloaded, not yet downloaded) files\n",
+    "    \"\"\"\n",
+    "\n",
+    "    finished = list()\n",
+    "    incomplete_download = dict()\n",
+    "    not_yet_on_gcs = dict()\n",
+    "    with (ftplib.FTP(ftp_server)) as ftp_socket:\n",
+    "        ftp_socket.login()\n",
+    "        ftp_socket.cwd(ftp_data_root_dir)\n",
+    "\n",
+    "        print(f\"Traversing test data dir {ftp_data_root_dir}/{gcs_dir_to_check} on FTP server {ftp_server} ...\")\n",
+    "        ftp_dir_tree = traverse_ftp_data_dir(ftp_socket, working_dir=gcs_dir_to_check)\n",
+    "        ftp_socket.quit()\n",
+    "        ftp_files_flat = flatten_ftp_dir_tree(ftp_dir_tree, ftp_socket, gcs_dir_to_check)\n",
+    "        print(f\"Found {len(ftp_files_flat)} files under {gcs_dir_to_check}\")\n",
+    "\n",
+    "    print(\"Matching FTP files with GCS files...\")\n",
+    "\n",
+    "    for ff, sz in ftp_files_flat.items():\n",
+    "        gs_path = re.sub(f'^{ftp_server}{ftp_data_root}', f'gs://{gcs_bucket_name}/{gcs_root_prefix}', ff)\n",
+    "        to_check = GcsPath(gs_path)\n",
+    "        if to_check.exists(client=gcs_client):\n",
+    "            gcs_sz = to_check.size(client=gcs_client)\n",
+    "            if gcs_sz is None:\n",
+    "                raise ValueError(f\"{gs_path} exist on GCS but doesn't have a size...\")\n",
+    "            if 0 == gcs_sz:\n",
+    "                not_yet_on_gcs[ff] = gs_path\n",
+    "            elif sz > gcs_sz:\n",
+    "                incomplete_download[ff] = {'full': sz, 'has': gcs_sz, 'gcs_path': gs_path}\n",
+    "            else:\n",
+    "                finished.append(ff)\n",
+    "        else:\n",
+    "            not_yet_on_gcs[ff] = gs_path\n",
+    "\n",
+    "    return finished, incomplete_download, not_yet_on_gcs\n"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "#### Test"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "outputs": [],
+   "source": [
+    "# ok, corrupt, jobs = collect_files_to_transfer(gcs_dir_to_check=test_dir, gcs_client=dev_storage_client,\n",
+    "#                                               ftp_server=ftp_site, ftp_data_root_dir=ftp_data_root,\n",
+    "#                                               gcs_bucket_name=gcs_bucket_name, gcs_root_prefix=gcs_root_prefix)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "outputs": [],
+   "source": [
+    "# corrupt"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "#### Test one dir where there's sub-dirs"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "outputs": [],
+   "source": [
+    "# test_dir = '20200108_PacBio_CLR_JAX'\n",
+    "# ok, corrupt, jobs = collect_files_to_transfer(gcs_dir_to_check=test_dir, gcs_client=dev_storage_client,\n",
+    "#                                               ftp_server=ftp_site, ftp_data_root_dir=ftp_data_root,\n",
+    "#                                               gcs_bucket_name=gcs_bucket_name, gcs_root_prefix=gcs_root_prefix)\n",
+    "# corrupt"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# Now real check"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "====================================================================================================\n",
+      "Traversing test data dir /vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi on FTP server ftp.1000genomes.ebi.ac.uk ...\n",
+      "Found 52 files under 20190925_PUR_PacBio_HiFi\n",
+      "Matching FTP files with GCS files...\n",
+      "====================================================================================================\n",
+      "====================================================================================================\n",
+      "Traversing test data dir /vol1/ftp/data_collections/HGSVC2/working/20191005_YRI_PacBio_NA19240_HiFi on FTP server ftp.1000genomes.ebi.ac.uk ...\n",
+      "Found 26 files under 20191005_YRI_PacBio_NA19240_HiFi\n",
+      "Matching FTP files with GCS files...\n",
+      "====================================================================================================\n",
+      "====================================================================================================\n",
+      "Traversing test data dir /vol1/ftp/data_collections/HGSVC2/working/20191031_CHS_PacBio_HG00512_HiFi on FTP server ftp.1000genomes.ebi.ac.uk ...\n",
+      "Found 68 files under 20191031_CHS_PacBio_HG00512_HiFi\n",
+      "Matching FTP files with GCS files...\n",
+      "====================================================================================================\n",
+      "====================================================================================================\n",
+      "Traversing test data dir /vol1/ftp/data_collections/HGSVC2/working/20191031_CHS_PacBio_HG00513_HiFi on FTP server ftp.1000genomes.ebi.ac.uk ...\n",
+      "Found 68 files under 20191031_CHS_PacBio_HG00513_HiFi\n",
+      "Matching FTP files with GCS files...\n",
+      "====================================================================================================\n",
+      "====================================================================================================\n",
+      "Traversing test data dir /vol1/ftp/data_collections/HGSVC2/working/20191205_YRI_PacBio_NA19238_HIFI on FTP server ftp.1000genomes.ebi.ac.uk ...\n",
+      "Found 34 files under 20191205_YRI_PacBio_NA19238_HIFI\n",
+      "Matching FTP files with GCS files...\n",
+      "====================================================================================================\n",
+      "====================================================================================================\n",
+      "Traversing test data dir /vol1/ftp/data_collections/HGSVC2/working/20191205_YRI_PacBio_NA19239_HIFI on FTP server ftp.1000genomes.ebi.ac.uk ...\n",
+      "Found 30 files under 20191205_YRI_PacBio_NA19239_HIFI\n",
+      "Matching FTP files with GCS files...\n",
+      "====================================================================================================\n",
+      "====================================================================================================\n",
+      "Traversing test data dir /vol1/ftp/data_collections/HGSVC2/working/20200108_PacBio_CLR_JAX on FTP server ftp.1000genomes.ebi.ac.uk ...\n",
+      "Found 70 files under 20200108_PacBio_CLR_JAX\n",
+      "Matching FTP files with GCS files...\n",
+      "====================================================================================================\n",
+      "====================================================================================================\n",
+      "Traversing test data dir /vol1/ftp/data_collections/HGSVC2/working/20200203_PacBio_CLR_EEE on FTP server ftp.1000genomes.ebi.ac.uk ...\n",
+      "Found 46 files under 20200203_PacBio_CLR_EEE\n",
+      "Matching FTP files with GCS files...\n",
+      "====================================================================================================\n",
+      "====================================================================================================\n",
+      "Traversing test data dir /vol1/ftp/data_collections/HGSVC2/working/20200212_PacBio_CLR_Devine on FTP server ftp.1000genomes.ebi.ac.uk ...\n",
+      "Found 80 files under 20200212_PacBio_CLR_Devine\n",
+      "Matching FTP files with GCS files...\n",
+      "====================================================================================================\n",
+      "====================================================================================================\n",
+      "Traversing test data dir /vol1/ftp/data_collections/HGSVC2/working/20200722_PUR_PacBio_HG00732_HiFi on FTP server ftp.1000genomes.ebi.ac.uk ...\n",
+      "Found 6 files under 20200722_PUR_PacBio_HG00732_HiFi\n",
+      "Matching FTP files with GCS files...\n",
+      "====================================================================================================\n",
+      "====================================================================================================\n",
+      "Traversing test data dir /vol1/ftp/data_collections/HGSVC2/working/20200731_CHS_PacBio_HG00514_CLR_reseq on FTP server ftp.1000genomes.ebi.ac.uk ...\n",
+      "Found 6 files under 20200731_CHS_PacBio_HG00514_CLR_reseq\n",
+      "Matching FTP files with GCS files...\n",
+      "====================================================================================================\n",
+      "====================================================================================================\n",
+      "Traversing test data dir /vol1/ftp/data_collections/HGSVC2/working/20200731_CHS_PacBio_HG00514_HiFi_reseq on FTP server ftp.1000genomes.ebi.ac.uk ...\n",
+      "Found 6 files under 20200731_CHS_PacBio_HG00514_HiFi_reseq\n",
+      "Matching FTP files with GCS files...\n",
+      "====================================================================================================\n",
+      "====================================================================================================\n",
+      "Traversing test data dir /vol1/ftp/data_collections/HGSVC2/working/20210509_UW_HiFi on FTP server ftp.1000genomes.ebi.ac.uk ...\n",
+      "Found 89 files under 20210509_UW_HiFi\n",
+      "Matching FTP files with GCS files...\n",
+      "====================================================================================================\n",
+      "====================================================================================================\n",
+      "Traversing test data dir /vol1/ftp/data_collections/HGSVC2/working/2021_PacBio_HIFI_JAX on FTP server ftp.1000genomes.ebi.ac.uk ...\n",
+      "Found 134 files under 2021_PacBio_HIFI_JAX\n",
+      "Matching FTP files with GCS files...\n",
+      "====================================================================================================\n"
+     ]
+    }
+   ],
+   "source": [
+    "missing_files_per_dataset = dict()\n",
+    "for d in gcs_dirs:\n",
+    "    print(\"====================================================================================================\")\n",
+    "    ok, corrupt, fresh = collect_files_to_transfer(gcs_dir_to_check=d, gcs_client=dev_storage_client,\n",
+    "                                                   ftp_server=ftp_site, ftp_data_root_dir=ftp_data_root,\n",
+    "                                                   gcs_bucket_name=gcs_bucket_name, gcs_root_prefix=gcs_root_prefix)\n",
+    "    missing_files_per_dataset[d] = {'corrupt': corrupt, 'fresh': fresh}\n",
+    "    print(\"====================================================================================================\")"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "outputs": [],
+   "source": [
+    "def keep_file(file_full_name: str) -> bool:\n",
+    "    \"\"\"\n",
+    "    Models a file filter, heavily project-dependent.\n",
+    "    \"\"\"\n",
+    "\n",
+    "    keep = not file_full_name.endswith('.fastq.gz')\n",
+    "\n",
+    "    is_meant_for_ccs = any(pat in file_full_name for pat in ['ccs', 'CCS', 'HiFi', 'HIFI'])\n",
+    "    is_pointing_to_non_ccs = any(pat in file_full_name for pat in ['subreads', 'scraps'])\n",
+    "    if is_meant_for_ccs and is_pointing_to_non_ccs:\n",
+    "        return False\n",
+    "\n",
+    "    return keep"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0 files in total to download, afresh.\n",
+      "{}\n"
+     ]
+    }
+   ],
+   "source": [
+    "all_missing_files = {k:v['fresh'] for k,v in missing_files_per_dataset.items()}\n",
+    "all_missing_files = {k: {ik: iv for ik, iv in v.items() if keep_file(iv)} for k, v in all_missing_files.items()}\n",
+    "all_missing_files = {k: v for k, v in all_missing_files.items() if v}\n",
+    "print(f\"{sum(len(v) for _, v in all_missing_files.items())} files in total to download, afresh.\")\n",
+    "pp.pprint(all_missing_files)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0 files in total to download, again.\n",
+      "{}\n"
+     ]
+    }
+   ],
+   "source": [
+    "all_corrupt_files = {k: {ik: iv['gcs_path'] for ik, iv in v['corrupt'].items()} for k,v in missing_files_per_dataset.items()}\n",
+    "all_corrupt_files = {k: {ik: iv for ik, iv in v.items() if keep_file(iv)} for k, v in all_corrupt_files.items()}\n",
+    "all_corrupt_files = {k: v for k, v in all_corrupt_files.items() if v}\n",
+    "print(f\"{sum(len(v) for _, v in all_corrupt_files.items())} files in total to download, again.\")\n",
+    "pp.pprint(all_corrupt_files)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "outputs": [],
+   "source": [
+    "for d, p in all_corrupt_files.items():\n",
+    "    corrupt_files_under_this_dir = missing_files_per_dataset[d].get('corrupt')\n",
+    "    for f in p.keys():\n",
+    "        info = corrupt_files_under_this_dir.get(f)\n",
+    "        n = re.sub(f'{ftp_site}{ftp_data_root}/', '', f)\n",
+    "        print(f\"{n}\\n\\t{info['has']} / {info['full']} bytes\")"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "outputs": [],
+   "source": [
+    "#### A different file-type filter"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "outputs": [],
+   "source": [],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "outputs": [],
+   "source": [
+    "def keep_file(file_full_name: str) -> bool:\n",
+    "    \"\"\"\n",
+    "    One purpose, get rid of incomplete *.fastq.gz\n",
+    "    \"\"\"\n",
+    "\n",
+    "    keep = True\n",
+    "    is_meant_for_ccs = any(pat in file_full_name for pat in ['ccs', 'CCS', 'HiFi', 'HIFI'])\n",
+    "    is_pointing_to_non_ccs = any(pat in file_full_name for pat in ['subreads', 'scraps'])\n",
+    "    if is_meant_for_ccs and is_pointing_to_non_ccs:\n",
+    "        return False\n",
+    "\n",
+    "    return keep"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3 files in total to download, afresh.\n",
+      "{   '20191031_CHS_PacBio_HG00513_HiFi': {   'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20191031_CHS_PacBio_HG00513_HiFi/HG00513_PacBio_Sequel2_CCS__EDEVI_20191004_S64018_PL100139348-1_D01.ccs.fastq.gz': 'gs://broad-dsde-methods-long-reads/datasets/HGSVC2/20191031_CHS_PacBio_HG00513_HiFi/HG00513_PacBio_Sequel2_CCS__EDEVI_20191004_S64018_PL100139348-1_D01.ccs.fastq.gz',\n",
+      "                                            'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20191031_CHS_PacBio_HG00513_HiFi/HG00513_PacBio_Sequel2_CCS__EDEVI_20191007_S64049_PL100139348-2_C01.ccs.fastq.gz': 'gs://broad-dsde-methods-long-reads/datasets/HGSVC2/20191031_CHS_PacBio_HG00513_HiFi/HG00513_PacBio_Sequel2_CCS__EDEVI_20191007_S64049_PL100139348-2_C01.ccs.fastq.gz',\n",
+      "                                            'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20191031_CHS_PacBio_HG00513_HiFi/HG00513_PacBio_Sequel2_CCS__EDEVI_20191007_S64049_PL100139348-2_D01.ccs.fastq.gz': 'gs://broad-dsde-methods-long-reads/datasets/HGSVC2/20191031_CHS_PacBio_HG00513_HiFi/HG00513_PacBio_Sequel2_CCS__EDEVI_20191007_S64049_PL100139348-2_D01.ccs.fastq.gz'}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "all_missing_files = {k:v['fresh'] for k,v in missing_files_per_dataset.items()}\n",
+    "all_missing_files = {k: {ik: iv for ik, iv in v.items() if keep_file(iv)} for k, v in all_missing_files.items()}\n",
+    "all_missing_files = {k: v for k, v in all_missing_files.items() if v}\n",
+    "print(f\"{sum(len(v) for _, v in all_missing_files.items())} files in total to download, afresh.\")\n",
+    "pp.pprint(all_missing_files)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "17 files in total to download, again.\n",
+      "{   '20190925_PUR_PacBio_HiFi': {   'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00731_20190925_EEE_m54329U_190528_231241.Q20.fastq.gz': 'gs://broad-dsde-methods-long-reads/datasets/HGSVC2/20190925_PUR_PacBio_HiFi/HG00731_20190925_EEE_m54329U_190528_231241.Q20.fastq.gz',\n",
+      "                                    'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00731_20190925_EEE_m54329U_190531_175004.Q20.fastq.gz': 'gs://broad-dsde-methods-long-reads/datasets/HGSVC2/20190925_PUR_PacBio_HiFi/HG00731_20190925_EEE_m54329U_190531_175004.Q20.fastq.gz',\n",
+      "                                    'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00731_20190925_EEE_m54329U_190601_235636.Q20.fastq.gz': 'gs://broad-dsde-methods-long-reads/datasets/HGSVC2/20190925_PUR_PacBio_HiFi/HG00731_20190925_EEE_m54329U_190601_235636.Q20.fastq.gz',\n",
+      "                                    'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00731_20190925_EEE_m54329U_190606_045526.Q20.fastq.gz': 'gs://broad-dsde-methods-long-reads/datasets/HGSVC2/20190925_PUR_PacBio_HiFi/HG00731_20190925_EEE_m54329U_190606_045526.Q20.fastq.gz',\n",
+      "                                    'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00731_20190925_EEE_m54329U_190906_205127.Q20.fastq.gz': 'gs://broad-dsde-methods-long-reads/datasets/HGSVC2/20190925_PUR_PacBio_HiFi/HG00731_20190925_EEE_m54329U_190906_205127.Q20.fastq.gz',\n",
+      "                                    'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190615_010947.Q20.fastq.gz': 'gs://broad-dsde-methods-long-reads/datasets/HGSVC2/20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190615_010947.Q20.fastq.gz',\n",
+      "                                    'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190617_231905.Q20.fastq.gz': 'gs://broad-dsde-methods-long-reads/datasets/HGSVC2/20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190617_231905.Q20.fastq.gz',\n",
+      "                                    'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190619_052546.Q20.fastq.gz': 'gs://broad-dsde-methods-long-reads/datasets/HGSVC2/20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190619_052546.Q20.fastq.gz',\n",
+      "                                    'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190629_180018.Q20.fastq.gz': 'gs://broad-dsde-methods-long-reads/datasets/HGSVC2/20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190629_180018.Q20.fastq.gz',\n",
+      "                                    'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190701_222759.Q20.fastq.gz': 'gs://broad-dsde-methods-long-reads/datasets/HGSVC2/20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190701_222759.Q20.fastq.gz',\n",
+      "                                    'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190827_173812.Q20.fastq.gz': 'gs://broad-dsde-methods-long-reads/datasets/HGSVC2/20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190827_173812.Q20.fastq.gz'},\n",
+      "    '20191031_CHS_PacBio_HG00512_HiFi': {   'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20191031_CHS_PacBio_HG00512_HiFi/HG00512_PacBio_Sequel2_CCS__EDEVI_20190920_S64018_PL100139347-1_A01.ccs.fastq.gz': 'gs://broad-dsde-methods-long-reads/datasets/HGSVC2/20191031_CHS_PacBio_HG00512_HiFi/HG00512_PacBio_Sequel2_CCS__EDEVI_20190920_S64018_PL100139347-1_A01.ccs.fastq.gz',\n",
+      "                                            'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20191031_CHS_PacBio_HG00512_HiFi/HG00512_PacBio_Sequel2_CCS__EDEVI_20190920_S64018_PL100139347-1_C01.ccs.fastq.gz': 'gs://broad-dsde-methods-long-reads/datasets/HGSVC2/20191031_CHS_PacBio_HG00512_HiFi/HG00512_PacBio_Sequel2_CCS__EDEVI_20190920_S64018_PL100139347-1_C01.ccs.fastq.gz',\n",
+      "                                            'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20191031_CHS_PacBio_HG00512_HiFi/HG00512_PacBio_Sequel2_CCS__EDEVI_20191004_S64018_PL100139347-2_A01.ccs.fastq.gz': 'gs://broad-dsde-methods-long-reads/datasets/HGSVC2/20191031_CHS_PacBio_HG00512_HiFi/HG00512_PacBio_Sequel2_CCS__EDEVI_20191004_S64018_PL100139347-2_A01.ccs.fastq.gz',\n",
+      "                                            'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20191031_CHS_PacBio_HG00512_HiFi/HG00512_PacBio_Sequel2_CCS__EDEVI_20191004_S64018_PL100139347-2_B01.ccs.fastq.gz': 'gs://broad-dsde-methods-long-reads/datasets/HGSVC2/20191031_CHS_PacBio_HG00512_HiFi/HG00512_PacBio_Sequel2_CCS__EDEVI_20191004_S64018_PL100139347-2_B01.ccs.fastq.gz',\n",
+      "                                            'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20191031_CHS_PacBio_HG00512_HiFi/HG00512_PacBio_Sequel2_CCS__EDEVI_20191007_S64049_PL100139347-2_A01.ccs.fastq.gz': 'gs://broad-dsde-methods-long-reads/datasets/HGSVC2/20191031_CHS_PacBio_HG00512_HiFi/HG00512_PacBio_Sequel2_CCS__EDEVI_20191007_S64049_PL100139347-2_A01.ccs.fastq.gz',\n",
+      "                                            'ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20191031_CHS_PacBio_HG00512_HiFi/HG00512_PacBio_Sequel2_CCS__EDEVI_20191007_S64049_PL100139347-2_B01.ccs.fastq.gz': 'gs://broad-dsde-methods-long-reads/datasets/HGSVC2/20191031_CHS_PacBio_HG00512_HiFi/HG00512_PacBio_Sequel2_CCS__EDEVI_20191007_S64049_PL100139347-2_B01.ccs.fastq.gz'}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "all_corrupt_files = {k: {ik: iv['gcs_path'] for ik, iv in v['corrupt'].items()} for k,v in missing_files_per_dataset.items()}\n",
+    "all_corrupt_files = {k: {ik: iv for ik, iv in v.items() if keep_file(iv)} for k, v in all_corrupt_files.items()}\n",
+    "all_corrupt_files = {k: v for k, v in all_corrupt_files.items() if v}\n",
+    "print(f\"{sum(len(v) for _, v in all_corrupt_files.items())} files in total to download, again.\")\n",
+    "pp.pprint(all_corrupt_files)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "20190925_PUR_PacBio_HiFi/HG00731_20190925_EEE_m54329U_190528_231241.Q20.fastq.gz\n",
+      "\t14392681785 / 15898357143 bytes\n",
+      "20190925_PUR_PacBio_HiFi/HG00731_20190925_EEE_m54329U_190531_175004.Q20.fastq.gz\n",
+      "\t7135434360 / 17040893093 bytes\n",
+      "20190925_PUR_PacBio_HiFi/HG00731_20190925_EEE_m54329U_190601_235636.Q20.fastq.gz\n",
+      "\t7121111496 / 16313818362 bytes\n",
+      "20190925_PUR_PacBio_HiFi/HG00731_20190925_EEE_m54329U_190606_045526.Q20.fastq.gz\n",
+      "\t7164008468 / 15568945475 bytes\n",
+      "20190925_PUR_PacBio_HiFi/HG00731_20190925_EEE_m54329U_190906_205127.Q20.fastq.gz\n",
+      "\t7121648588 / 16591637237 bytes\n",
+      "20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190615_010947.Q20.fastq.gz\n",
+      "\t7103838920 / 9966703426 bytes\n",
+      "20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190617_231905.Q20.fastq.gz\n",
+      "\t7116162640 / 9486694384 bytes\n",
+      "20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190619_052546.Q20.fastq.gz\n",
+      "\t7197075084 / 7594807936 bytes\n",
+      "20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190629_180018.Q20.fastq.gz\n",
+      "\t7099348620 / 12603662064 bytes\n",
+      "20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190701_222759.Q20.fastq.gz\n",
+      "\t7060844704 / 13612951231 bytes\n",
+      "20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190827_173812.Q20.fastq.gz\n",
+      "\t7092539528 / 24059030269 bytes\n",
+      "20191031_CHS_PacBio_HG00512_HiFi/HG00512_PacBio_Sequel2_CCS__EDEVI_20190920_S64018_PL100139347-1_A01.ccs.fastq.gz\n",
+      "\t5179667784 / 14112189974 bytes\n",
+      "20191031_CHS_PacBio_HG00512_HiFi/HG00512_PacBio_Sequel2_CCS__EDEVI_20190920_S64018_PL100139347-1_C01.ccs.fastq.gz\n",
+      "\t5232083532 / 9334292195 bytes\n",
+      "20191031_CHS_PacBio_HG00512_HiFi/HG00512_PacBio_Sequel2_CCS__EDEVI_20191004_S64018_PL100139347-2_A01.ccs.fastq.gz\n",
+      "\t5193840644 / 17013343637 bytes\n",
+      "20191031_CHS_PacBio_HG00512_HiFi/HG00512_PacBio_Sequel2_CCS__EDEVI_20191004_S64018_PL100139347-2_B01.ccs.fastq.gz\n",
+      "\t1033466116 / 15989512583 bytes\n",
+      "20191031_CHS_PacBio_HG00512_HiFi/HG00512_PacBio_Sequel2_CCS__EDEVI_20191007_S64049_PL100139347-2_A01.ccs.fastq.gz\n",
+      "\t647900128 / 16417539654 bytes\n",
+      "20191031_CHS_PacBio_HG00512_HiFi/HG00512_PacBio_Sequel2_CCS__EDEVI_20191007_S64049_PL100139347-2_B01.ccs.fastq.gz\n",
+      "\t2766842196 / 13762754072 bytes\n"
+     ]
+    }
+   ],
+   "source": [
+    "for d, p in all_corrupt_files.items():\n",
+    "    corrupt_files_under_this_dir = missing_files_per_dataset[d].get('corrupt')\n",
+    "    for f in p.keys():\n",
+    "        info = corrupt_files_under_this_dir.get(f)\n",
+    "        n = re.sub(f'{ftp_site}{ftp_data_root}/', '', f)\n",
+    "        print(f\"{n}\\n\\t{info['has']} / {info['full']} bytes\")"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Removing gs://broad-dsde-methods-long-reads/datasets/HGSVC2/20190925_PUR_PacBio_HiFi/HG00731_20190925_EEE_m54329U_190528_231241.Q20.fastq.gz...\n",
+      "/ [1 objects]                                                                   \r\n",
+      "Operation completed over 1 objects.                                              \n",
+      "Removing gs://broad-dsde-methods-long-reads/datasets/HGSVC2/20190925_PUR_PacBio_HiFi/HG00731_20190925_EEE_m54329U_190531_175004.Q20.fastq.gz...\n",
+      "/ [1 objects]                                                                   \r\n",
+      "Operation completed over 1 objects.                                              \n",
+      "Removing gs://broad-dsde-methods-long-reads/datasets/HGSVC2/20190925_PUR_PacBio_HiFi/HG00731_20190925_EEE_m54329U_190601_235636.Q20.fastq.gz...\n",
+      "/ [1 objects]                                                                   \r\n",
+      "Operation completed over 1 objects.                                              \n",
+      "Removing gs://broad-dsde-methods-long-reads/datasets/HGSVC2/20190925_PUR_PacBio_HiFi/HG00731_20190925_EEE_m54329U_190606_045526.Q20.fastq.gz...\n",
+      "/ [1 objects]                                                                   \r\n",
+      "Operation completed over 1 objects.                                              \n",
+      "Removing gs://broad-dsde-methods-long-reads/datasets/HGSVC2/20190925_PUR_PacBio_HiFi/HG00731_20190925_EEE_m54329U_190906_205127.Q20.fastq.gz...\n",
+      "/ [1 objects]                                                                   \r\n",
+      "Operation completed over 1 objects.                                              \n",
+      "Removing gs://broad-dsde-methods-long-reads/datasets/HGSVC2/20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190615_010947.Q20.fastq.gz...\n",
+      "/ [1 objects]                                                                   \r\n",
+      "Operation completed over 1 objects.                                              \n",
+      "Removing gs://broad-dsde-methods-long-reads/datasets/HGSVC2/20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190617_231905.Q20.fastq.gz...\n",
+      "/ [1 objects]                                                                   \r\n",
+      "Operation completed over 1 objects.                                              \n",
+      "Removing gs://broad-dsde-methods-long-reads/datasets/HGSVC2/20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190619_052546.Q20.fastq.gz...\n",
+      "/ [1 objects]                                                                   \r\n",
+      "Operation completed over 1 objects.                                              \n",
+      "Removing gs://broad-dsde-methods-long-reads/datasets/HGSVC2/20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190629_180018.Q20.fastq.gz...\n",
+      "/ [1 objects]                                                                   \r\n",
+      "Operation completed over 1 objects.                                              \n",
+      "Removing gs://broad-dsde-methods-long-reads/datasets/HGSVC2/20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190701_222759.Q20.fastq.gz...\n",
+      "/ [1 objects]                                                                   \r\n",
+      "Operation completed over 1 objects.                                              \n",
+      "Removing gs://broad-dsde-methods-long-reads/datasets/HGSVC2/20190925_PUR_PacBio_HiFi/HG00733_20190925_EEE_m54329U_190827_173812.Q20.fastq.gz...\n",
+      "/ [1 objects]                                                                   \r\n",
+      "Operation completed over 1 objects.                                              \n",
+      "Removing gs://broad-dsde-methods-long-reads/datasets/HGSVC2/20191031_CHS_PacBio_HG00512_HiFi/HG00512_PacBio_Sequel2_CCS__EDEVI_20190920_S64018_PL100139347-1_A01.ccs.fastq.gz...\n",
+      "/ [1 objects]                                                                   \r\n",
+      "Operation completed over 1 objects.                                              \n",
+      "Removing gs://broad-dsde-methods-long-reads/datasets/HGSVC2/20191031_CHS_PacBio_HG00512_HiFi/HG00512_PacBio_Sequel2_CCS__EDEVI_20190920_S64018_PL100139347-1_C01.ccs.fastq.gz...\n",
+      "/ [1 objects]                                                                   \r\n",
+      "Operation completed over 1 objects.                                              \n",
+      "Removing gs://broad-dsde-methods-long-reads/datasets/HGSVC2/20191031_CHS_PacBio_HG00512_HiFi/HG00512_PacBio_Sequel2_CCS__EDEVI_20191004_S64018_PL100139347-2_A01.ccs.fastq.gz...\n",
+      "/ [1 objects]                                                                   \r\n",
+      "Operation completed over 1 objects.                                              \n",
+      "Removing gs://broad-dsde-methods-long-reads/datasets/HGSVC2/20191031_CHS_PacBio_HG00512_HiFi/HG00512_PacBio_Sequel2_CCS__EDEVI_20191004_S64018_PL100139347-2_B01.ccs.fastq.gz...\n",
+      "/ [1 objects]                                                                   \r\n",
+      "Operation completed over 1 objects.                                              \n",
+      "Removing gs://broad-dsde-methods-long-reads/datasets/HGSVC2/20191031_CHS_PacBio_HG00512_HiFi/HG00512_PacBio_Sequel2_CCS__EDEVI_20191007_S64049_PL100139347-2_A01.ccs.fastq.gz...\n",
+      "/ [1 objects]                                                                   \r\n",
+      "Operation completed over 1 objects.                                              \n",
+      "Removing gs://broad-dsde-methods-long-reads/datasets/HGSVC2/20191031_CHS_PacBio_HG00512_HiFi/HG00512_PacBio_Sequel2_CCS__EDEVI_20191007_S64049_PL100139347-2_B01.ccs.fastq.gz...\n",
+      "/ [1 objects]                                                                   \r\n",
+      "Operation completed over 1 objects.                                              \n"
+     ]
+    }
+   ],
+   "source": [
+    "if 0 < len(all_corrupt_files):\n",
+    "    # remove corrupt files from cloud first:\n",
+    "    # !!!!!!!!!! MAKE SURE THEY ARE NOT IN THE PROCESS OF BEING DOWNLOADED !!!!!!!!!!\n",
+    "    for k, v in all_corrupt_files.items():\n",
+    "        for _, gs_path in v.items():\n",
+    "            cmd = f'gsutil rm {gs_path}'\n",
+    "            os.system(cmd)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "#### print out file downloading commands"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "aria2c \\\n",
+      " --check-integrity --continue --max-tries=0 \\\n",
+      "  --dir=gs/datasets/HGSVC2/20200108_PacBio_CLR_JAX/20200124_JAX_CLR_additional_samples/ \\\n",
+      "  --log=20200108_PacBio_CLR_JAX__20200124_JAX_CLR_additional_samples__HG03732_20200108_CLEE_m54336U_191230_150456.subreads.bam.wget-log \\\n",
+      "  --out=HG03732_20200108_CLEE_m54336U_191230_150456.subreads.bam \\\n",
+      "  ftP://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20200108_PacBio_CLR_JAX/20200124_JAX_CLR_additional_samples/HG03732_20200108_CLEE_m54336U_191230_150456.subreads.bam\n",
+      "aria2c \\\n",
+      " --check-integrity --continue --max-tries=0 \\\n",
+      "  --dir=gs/datasets/HGSVC2/20200108_PacBio_CLR_JAX/20200124_JAX_CLR_additional_samples/ \\\n",
+      "  --log=20200108_PacBio_CLR_JAX__20200124_JAX_CLR_additional_samples__HG03732_20200116_CLEE_m54336U_200112_083928.subreads.bam.wget-log \\\n",
+      "  --out=HG03732_20200116_CLEE_m54336U_200112_083928.subreads.bam \\\n",
+      "  ftP://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20200108_PacBio_CLR_JAX/20200124_JAX_CLR_additional_samples/HG03732_20200116_CLEE_m54336U_200112_083928.subreads.bam\n",
+      "aria2c \\\n",
+      " --check-integrity --continue --max-tries=0 \\\n",
+      "  --dir=gs/datasets/HGSVC2/20200108_PacBio_CLR_JAX/20200213_JAX_CLR_additional_samples/ \\\n",
+      "  --log=20200108_PacBio_CLR_JAX__20200213_JAX_CLR_additional_samples__HG01596_20200208_CLEE_m54336U_200203_205756.subreads.bam.wget-log \\\n",
+      "  --out=HG01596_20200208_CLEE_m54336U_200203_205756.subreads.bam \\\n",
+      "  ftP://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20200108_PacBio_CLR_JAX/20200213_JAX_CLR_additional_samples/HG01596_20200208_CLEE_m54336U_200203_205756.subreads.bam\n",
+      "aria2c \\\n",
+      " --check-integrity --continue --max-tries=0 \\\n",
+      "  --dir=gs/datasets/HGSVC2/20200108_PacBio_CLR_JAX/20200213_JAX_CLR_additional_samples/ \\\n",
+      "  --log=20200108_PacBio_CLR_JAX__20200213_JAX_CLR_additional_samples__HG01596_20200208_CLEE_m54336U_200204_122142.subreads.bam.wget-log \\\n",
+      "  --out=HG01596_20200208_CLEE_m54336U_200204_122142.subreads.bam \\\n",
+      "  ftP://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20200108_PacBio_CLR_JAX/20200213_JAX_CLR_additional_samples/HG01596_20200208_CLEE_m54336U_200204_122142.subreads.bam\n",
+      "aria2c \\\n",
+      " --check-integrity --continue --max-tries=0 \\\n",
+      "  --dir=gs/datasets/HGSVC2/20200108_PacBio_CLR_JAX/20200310_JAX_CLR_additional_samples/ \\\n",
+      "  --log=20200108_PacBio_CLR_JAX__20200310_JAX_CLR_additional_samples__NA19240_20200306_CLEE_m54336U_200305_165343.subreads.bam.wget-log \\\n",
+      "  --out=NA19240_20200306_CLEE_m54336U_200305_165343.subreads.bam \\\n",
+      "  ftP://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20200108_PacBio_CLR_JAX/20200310_JAX_CLR_additional_samples/NA19240_20200306_CLEE_m54336U_200305_165343.subreads.bam\n",
+      "aria2c \\\n",
+      " --check-integrity --continue --max-tries=0 \\\n",
+      "  --dir=gs/datasets/HGSVC2/20200108_PacBio_CLR_JAX/20200627_NA19238_PacBio_CLR_JAX_additional/ \\\n",
+      "  --log=20200108_PacBio_CLR_JAX__20200627_NA19238_PacBio_CLR_JAX_additional__NA19238_20200508_CLEE_S64049_A01.subreads.bam.wget-log \\\n",
+      "  --out=NA19238_20200508_CLEE_S64049_A01.subreads.bam \\\n",
+      "  ftP://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20200108_PacBio_CLR_JAX/20200627_NA19238_PacBio_CLR_JAX_additional/NA19238_20200508_CLEE_S64049_A01.subreads.bam\n",
+      "aria2c \\\n",
+      " --check-integrity --continue --max-tries=0 \\\n",
+      "  --dir=gs/datasets/HGSVC2/20200108_PacBio_CLR_JAX/20200627_NA19238_PacBio_CLR_JAX_additional/ \\\n",
+      "  --log=20200108_PacBio_CLR_JAX__20200627_NA19238_PacBio_CLR_JAX_additional__NA19238_20200508_CLEE_S64049_B01.subreads.bam.wget-log \\\n",
+      "  --out=NA19238_20200508_CLEE_S64049_B01.subreads.bam \\\n",
+      "  ftP://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20200108_PacBio_CLR_JAX/20200627_NA19238_PacBio_CLR_JAX_additional/NA19238_20200508_CLEE_S64049_B01.subreads.bam\n",
+      "aria2c \\\n",
+      " --check-integrity --continue --max-tries=0 \\\n",
+      "  --dir=gs/datasets/HGSVC2/20200108_PacBio_CLR_JAX/ \\\n",
+      "  --log=20200108_PacBio_CLR_JAX__HG00171_20200108_CLEE_m54336U_191222_015919.subreads.bam.wget-log \\\n",
+      "  --out=HG00171_20200108_CLEE_m54336U_191222_015919.subreads.bam \\\n",
+      "  ftP://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20200108_PacBio_CLR_JAX/HG00171_20200108_CLEE_m54336U_191222_015919.subreads.bam\n",
+      "aria2c \\\n",
+      " --check-integrity --continue --max-tries=0 \\\n",
+      "  --dir=gs/datasets/HGSVC2/20200108_PacBio_CLR_JAX/ \\\n",
+      "  --log=20200108_PacBio_CLR_JAX__HG00171_20200108_CLEE_m54336U_191225_081415.subreads.bam.wget-log \\\n",
+      "  --out=HG00171_20200108_CLEE_m54336U_191225_081415.subreads.bam \\\n",
+      "  ftP://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20200108_PacBio_CLR_JAX/HG00171_20200108_CLEE_m54336U_191225_081415.subreads.bam\n",
+      "aria2c \\\n",
+      " --check-integrity --continue --max-tries=0 \\\n",
+      "  --dir=gs/datasets/HGSVC2/20200108_PacBio_CLR_JAX/ \\\n",
+      "  --log=20200108_PacBio_CLR_JAX__HG01114_20200108_CLEE_m54336U_191205_151927.subreads.bam.wget-log \\\n",
+      "  --out=HG01114_20200108_CLEE_m54336U_191205_151927.subreads.bam \\\n",
+      "  ftP://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20200108_PacBio_CLR_JAX/HG01114_20200108_CLEE_m54336U_191205_151927.subreads.bam\n",
+      "aria2c \\\n",
+      " --check-integrity --continue --max-tries=0 \\\n",
+      "  --dir=gs/datasets/HGSVC2/20200108_PacBio_CLR_JAX/ \\\n",
+      "  --log=20200108_PacBio_CLR_JAX__HG01114_20200108_CLEE_m64039_191019_093747.subreads.bam.wget-log \\\n",
+      "  --out=HG01114_20200108_CLEE_m64039_191019_093747.subreads.bam \\\n",
+      "  ftP://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20200108_PacBio_CLR_JAX/HG01114_20200108_CLEE_m64039_191019_093747.subreads.bam\n",
+      "aria2c \\\n",
+      " --check-integrity --continue --max-tries=0 \\\n",
+      "  --dir=gs/datasets/HGSVC2/20200108_PacBio_CLR_JAX/ \\\n",
+      "  --log=20200108_PacBio_CLR_JAX__HG02587_20200108_CLEE_m54336U_191012_180310.subreads.bam.wget-log \\\n",
+      "  --out=HG02587_20200108_CLEE_m54336U_191012_180310.subreads.bam \\\n",
+      "  ftP://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20200108_PacBio_CLR_JAX/HG02587_20200108_CLEE_m54336U_191012_180310.subreads.bam\n",
+      "aria2c \\\n",
+      " --check-integrity --continue --max-tries=0 \\\n",
+      "  --dir=gs/datasets/HGSVC2/20200108_PacBio_CLR_JAX/ \\\n",
+      "  --log=20200108_PacBio_CLR_JAX__HG02587_20200108_CLEE_m54336U_191014_193201.subreads.bam.wget-log \\\n",
+      "  --out=HG02587_20200108_CLEE_m54336U_191014_193201.subreads.bam \\\n",
+      "  ftP://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20200108_PacBio_CLR_JAX/HG02587_20200108_CLEE_m54336U_191014_193201.subreads.bam\n",
+      "aria2c \\\n",
+      " --check-integrity --continue --max-tries=0 \\\n",
+      "  --dir=gs/datasets/HGSVC2/20200108_PacBio_CLR_JAX/ \\\n",
+      "  --log=20200108_PacBio_CLR_JAX__HG02587_20200108_CLEE_m54336U_191229_075124.subreads.bam.wget-log \\\n",
+      "  --out=HG02587_20200108_CLEE_m54336U_191229_075124.subreads.bam \\\n",
+      "  ftP://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20200108_PacBio_CLR_JAX/HG02587_20200108_CLEE_m54336U_191229_075124.subreads.bam\n",
+      "aria2c \\\n",
+      " --check-integrity --continue --max-tries=0 \\\n",
+      "  --dir=gs/datasets/HGSVC2/20200108_PacBio_CLR_JAX/ \\\n",
+      "  --log=20200108_PacBio_CLR_JAX__HG03721_20200108_CLEE_m54336U_191208_211521.subreads.bam.wget-log \\\n",
+      "  --out=HG03721_20200108_CLEE_m54336U_191208_211521.subreads.bam \\\n",
+      "  ftP://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20200108_PacBio_CLR_JAX/HG03721_20200108_CLEE_m54336U_191208_211521.subreads.bam\n",
+      "aria2c \\\n",
+      " --check-integrity --continue --max-tries=0 \\\n",
+      "  --dir=gs/datasets/HGSVC2/20200108_PacBio_CLR_JAX/ \\\n",
+      "  --log=20200108_PacBio_CLR_JAX__HG03721_20200108_CLEE_m54336U_191209_235126.subreads.bam.wget-log \\\n",
+      "  --out=HG03721_20200108_CLEE_m54336U_191209_235126.subreads.bam \\\n",
+      "  ftP://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20200108_PacBio_CLR_JAX/HG03721_20200108_CLEE_m54336U_191209_235126.subreads.bam\n",
+      "aria2c \\\n",
+      " --check-integrity --continue --max-tries=0 \\\n",
+      "  --dir=gs/datasets/HGSVC2/20200108_PacBio_CLR_JAX/ \\\n",
+      "  --log=20200108_PacBio_CLR_JAX__NA19239_20200108_CLEE_m54336U_191222_173559.subreads.bam.wget-log \\\n",
+      "  --out=NA19239_20200108_CLEE_m54336U_191222_173559.subreads.bam \\\n",
+      "  ftP://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20200108_PacBio_CLR_JAX/NA19239_20200108_CLEE_m54336U_191222_173559.subreads.bam\n",
+      "aria2c \\\n",
+      " --check-integrity --continue --max-tries=0 \\\n",
+      "  --dir=gs/datasets/HGSVC2/20200108_PacBio_CLR_JAX/ \\\n",
+      "  --log=20200108_PacBio_CLR_JAX__NA19239_20200108_CLEE_m54336U_191225_235049.subreads.bam.wget-log \\\n",
+      "  --out=NA19239_20200108_CLEE_m54336U_191225_235049.subreads.bam \\\n",
+      "  ftP://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20200108_PacBio_CLR_JAX/NA19239_20200108_CLEE_m54336U_191225_235049.subreads.bam\n",
+      "aria2c \\\n",
+      " --check-integrity --continue --max-tries=0 \\\n",
+      "  --dir=gs/datasets/HGSVC2/20200203_PacBio_CLR_EEE/ \\\n",
+      "  --log=20200203_PacBio_CLR_EEE__HG00732.WGS.PUR.20191214_r54329U_20191212_232645_C01.CLR.bam.wget-log \\\n",
+      "  --out=HG00732.WGS.PUR.20191214_r54329U_20191212_232645_C01.CLR.bam \\\n",
+      "  ftP://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20200203_PacBio_CLR_EEE/HG00732.WGS.PUR.20191214_r54329U_20191212_232645_C01.CLR.bam\n",
+      "aria2c \\\n",
+      " --check-integrity --continue --max-tries=0 \\\n",
+      "  --dir=gs/datasets/HGSVC2/20200203_PacBio_CLR_EEE/ \\\n",
+      "  --log=20200203_PacBio_CLR_EEE__NA12329.WGS.CEU.20191206_r64076_20191206_001229_A01.CLR.bam.wget-log \\\n",
+      "  --out=NA12329.WGS.CEU.20191206_r64076_20191206_001229_A01.CLR.bam \\\n",
+      "  ftP://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20200203_PacBio_CLR_EEE/NA12329.WGS.CEU.20191206_r64076_20191206_001229_A01.CLR.bam\n",
+      "aria2c \\\n",
+      " --check-integrity --continue --max-tries=0 \\\n",
+      "  --dir=gs/datasets/HGSVC2/20200203_PacBio_CLR_EEE/ \\\n",
+      "  --log=20200203_PacBio_CLR_EEE__NA12329.WGS.CEU.20191207_r64076_20191206_232343_A01.CLR.bam.wget-log \\\n",
+      "  --out=NA12329.WGS.CEU.20191207_r64076_20191206_232343_A01.CLR.bam \\\n",
+      "  ftP://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20200203_PacBio_CLR_EEE/NA12329.WGS.CEU.20191207_r64076_20191206_232343_A01.CLR.bam\n",
+      "aria2c \\\n",
+      " --check-integrity --continue --max-tries=0 \\\n",
+      "  --dir=gs/datasets/HGSVC2/20200203_PacBio_CLR_EEE/ \\\n",
+      "  --log=20200203_PacBio_CLR_EEE__NA19983.WGS.ASW.20191206_r54329U_20191206_001107_A01.CLR.bam.wget-log \\\n",
+      "  --out=NA19983.WGS.ASW.20191206_r54329U_20191206_001107_A01.CLR.bam \\\n",
+      "  ftP://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/HGSVC2/working/20200203_PacBio_CLR_EEE/NA19983.WGS.ASW.20191206_r54329U_20191206_001107_A01.CLR.bam\n"
+     ]
+    }
+   ],
+   "source": [
+    "if 0 < len(all_missing_files):\n",
+    "    for k,v in all_missing_files.items():\n",
+    "        for ftp_path, gs_path in v.items():\n",
+    "\n",
+    "            local_relative_path = re.sub(gcs_leading_prefix, '', gs_path)\n",
+    "            local_prefix = gcsfuse_local_leading_prefix + '/'.join(local_relative_path.split('/')[:-1]) + '/'\n",
+    "            log_file = '__'.join(ftp_path.split('/')[6:]) + \".aria2-log\"\n",
+    "            output_file_name = local_relative_path.split('/')[-1]\n",
+    "            cmd = f'aria2c \\\\\\n {aria2_flags} \\\\\\n  --dir={local_prefix} \\\\\\n  --log={log_file} \\\\\\n  --out={output_file_name} \\\\\\n  ftp://{ftp_path}'\n",
+    "            print(cmd)\n",
+    "            with open(f'/Users/shuang/Desktop/hgsvc2_more_downloads/aria2/{output_file_name}.download.sh', 'w') as out:\n",
+    "                out.write('#!/bin/bash\\n\\nset -eu\\n\\n')\n",
+    "                out.write(cmd)\n",
+    "                out.write('\\n')"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "if 0 < len(all_corrupt_files):\n",
+    "    # remove corrupt files from cloud first:\n",
+    "    # !!!!!!!!!! MAKE SURE THEY ARE NOT IN THE PROCESS OF BEING DOWNLOADED !!!!!!!!!!\n",
+    "    for k, v in all_corrupt_files.items():\n",
+    "        for _, gs_path in v.items():\n",
+    "            cmd = f'gsutil rm {gs_path}'\n",
+    "            os.system(cmd)\n",
+    "    for k,v in all_corrupt_files.items():\n",
+    "        for ftp_path, gs_path in v.items():\n",
+    "\n",
+    "            local_relative_path = re.sub(gcs_leading_prefix, '', gs_path)\n",
+    "            local_prefix = gcsfuse_local_leading_prefix + '/'.join(local_relative_path.split('/')[:-1]) + '/'\n",
+    "            log_file = '__'.join(ftp_path.split('/')[6:]) + \".wget-log\"\n",
+    "            output_file_name = local_relative_path.split('/')[-1]\n",
+    "            cmd = f'aria2c \\\\\\n {aria2_flags} \\\\\\n  --dir={local_prefix} \\\\\\n  --log={log_file} \\\\\\n  --out={output_file_name} \\\\\\n  ftp://{ftp_path}'\n",
+    "            print(cmd)\n",
+    "            with open(f'/Users/shuang/Desktop/hgsvc2_more_downloads/aria2/{output_file_name}.download.sh', 'w') as out:\n",
+    "                out.write('#!/bin/bash\\n\\nset -eu\\n\\n')\n",
+    "                out.write(cmd)\n",
+    "                out.write('\\n')"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
i.e. check if files are successfully transferred from FTP to GCS.

Note that it uses wget2, which takes some hassle to install on Ubuntu 18.04.


**UPDATE**
Use aria2, even better!

Note this assumes you are familiar with [`gcsfuse`](https://github.com/GoogleCloudPlatform/gcsfuse), which saves much time in uploading files (uploading to GCS while downloading from FTP).