### PR TITLE
Randomly assign zones to more intensive subworkflows

### DIFF
--- a/wdl/tasks/CCSPepper.wdl
+++ b/wdl/tasks/CCSPepper.wdl
@@ -25,6 +25,15 @@ workflow CCSPepper {
 
         Int dv_threads
         Int dv_memory
+
+        String zones = "us-central1-b us-central1-c"
+    }
+
+    parameter_meta {
+        # when running large scale workflows, we sometimes see errors like the following
+        #   A resource limit has delayed the operation: generic::resource_exhausted: allocating: selecting resources: selecting region and zone:
+        #   no available zones: 2763 LOCAL_SSD_TOTAL_GB (738/30000 available) usage too high
+        zones: "select which zone (GCP) to run this task"
     }
 
     call Pepper as get_hap_tagged_bam {
@@ -34,7 +43,8 @@ workflow CCSPepper {
             ref_fasta = ref_fasta,
             ref_fasta_fai = ref_fasta_fai,
             threads = pepper_threads,
-            memory = pepper_memory
+            memory = pepper_memory,
+            zones = zones
     }
 
     call DV as deep_variant {
@@ -44,7 +54,8 @@ workflow CCSPepper {
             ref_fasta = ref_fasta,
             ref_fasta_fai = ref_fasta_fai,
             threads = dv_threads,
-            memory = dv_memory
+            memory = dv_memory,
+            zones = zones
     }
 
     output {
@@ -69,6 +80,7 @@ task Pepper {
 
         Int threads
         Int memory
+        String zones
 
         RuntimeAttr? runtime_attr_override
     }
@@ -138,6 +150,7 @@ task Pepper {
         cpu:                    select_first([runtime_attr.cpu_cores,         default_attr.cpu_cores])
         memory:                 select_first([runtime_attr.mem_gb,            default_attr.mem_gb]) + " GiB"
         disks: "local-disk " +  select_first([runtime_attr.disk_gb,           default_attr.disk_gb]) + " HDD"
+        zones: zones
         bootDiskSizeGb:         select_first([runtime_attr.boot_disk_gb,      default_attr.boot_disk_gb])
         preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
         maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])
@@ -156,6 +169,7 @@ task DV {
 
         Int threads
         Int memory
+        String zones
 
         RuntimeAttr? runtime_attr_override
     }
@@ -225,6 +239,7 @@ task DV {
         cpu:                    select_first([runtime_attr.cpu_cores,         default_attr.cpu_cores])
         memory:                 select_first([runtime_attr.mem_gb,            default_attr.mem_gb]) + " GiB"
         disks: "local-disk " +  select_first([runtime_attr.disk_gb,           default_attr.disk_gb]) + " HDD"
+        zones: zones
         bootDiskSizeGb:         select_first([runtime_attr.boot_disk_gb,      default_attr.boot_disk_gb])
         preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
         maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])
@@ -249,6 +264,7 @@ task MarginPhase {
         File ref_fasta_fai
 
         Int memory
+        String zones
 
         RuntimeAttr? runtime_attr_override
     }
@@ -307,6 +323,7 @@ task MarginPhase {
         cpu:                    select_first([runtime_attr.cpu_cores,         default_attr.cpu_cores])
         memory:                 select_first([runtime_attr.mem_gb,            default_attr.mem_gb]) + " GiB"
         disks: "local-disk " +  select_first([runtime_attr.disk_gb,           default_attr.disk_gb]) + " HDD"
+        zones: zones
         bootDiskSizeGb:         select_first([runtime_attr.boot_disk_gb,      default_attr.boot_disk_gb])
         preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
         maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])

--- a/wdl/tasks/CallVariantsONT.wdl
+++ b/wdl/tasks/CallVariantsONT.wdl
@@ -57,6 +57,8 @@ workflow CallVariants {
     # Block for small variants handling
     ######################################################################
 
+    call Utils.RandomZoneSpewer as arbitrary {input: num_of_zones = 3}
+
     # todo: merge the two scattering scheme into a better one
     if (call_small_variants) {
         # Scatter by chromosome
@@ -89,7 +91,8 @@ workflow CallVariants {
                     sites_vcf = sites_vcf,
                     sites_vcf_tbi = sites_vcf_tbi,
 
-                    preset = "ONT"
+                    preset = "ONT",
+                    zones = arbitrary.zones
             }
         }
 
@@ -132,7 +135,8 @@ workflow CallVariants {
                         ref_fasta     = ref_fasta,
                         ref_fasta_fai = ref_fasta_fai,
                         threads       = select_first([dvp_threads]),
-                        memory        = select_first([dvp_memory])
+                        memory        = select_first([dvp_memory]),
+                        zones = arbitrary.zones
                 }
             }
 
@@ -196,7 +200,8 @@ workflow CallVariants {
                         ref_fasta_fai = ref_fasta_fai,
                         prefix = prefix,
                         tandem_repeat_bed = tandem_repeat_bed,
-                        is_ccs = false
+                        is_ccs = false,
+                        zones = arbitrary.zones
                 }
 
                 call Sniffles.Sniffles {
@@ -249,7 +254,8 @@ workflow CallVariants {
                     ref_fasta_fai = ref_fasta_fai,
                     prefix = prefix,
                     tandem_repeat_bed = tandem_repeat_bed,
-                    is_ccs = false
+                    is_ccs = false,
+                    zones = arbitrary.zones
             }
             call VariantUtils.ZipAndIndexVCF as ZipAndIndexPBSV {input: vcf = PBSVslow.vcf }
 

--- a/wdl/tasks/CallVariantsPBCCS.wdl
+++ b/wdl/tasks/CallVariantsPBCCS.wdl
@@ -57,6 +57,8 @@ workflow CallVariants {
     # Block for small variants handling
     ######################################################################
 
+    call Utils.RandomZoneSpewer as arbitrary {input: num_of_zones = 3}
+
     # todo: merge the two scattering scheme into a better one
     if (call_small_variants) {
         # Scatter by chromosome
@@ -89,7 +91,8 @@ workflow CallVariants {
                     sites_vcf = sites_vcf,
                     sites_vcf_tbi = sites_vcf_tbi,
 
-                    preset = "CCS"
+                    preset = "CCS",
+                    zones = arbitrary.zones
             }
         }
 
@@ -136,7 +139,8 @@ workflow CallVariants {
                         pepper_threads = select_first([dvp_threads]),
                         pepper_memory  = select_first([dvp_memory]),
                         dv_threads = select_first([dvp_threads]),
-                        dv_memory  = select_first([dvp_memory])
+                        dv_memory  = select_first([dvp_memory]),
+                        zones = arbitrary.zones
                 }
             }
 
@@ -171,7 +175,8 @@ workflow CallVariants {
                     unphased_vcf_tbi = MergeDeepVariantVCFs.tbi,
                     ref_fasta     = ref_fasta,
                     ref_fasta_fai = ref_fasta_fai,
-                    memory        = select_first([dvp_memory, 64])
+                    memory        = select_first([dvp_memory, 64]),
+                    zones = arbitrary.zones
             }
         }
     }
@@ -206,7 +211,8 @@ workflow CallVariants {
                         ref_fasta_fai = ref_fasta_fai,
                         prefix = prefix,
                         tandem_repeat_bed = tandem_repeat_bed,
-                        is_ccs = true
+                        is_ccs = true,
+                        zones = arbitrary.zones
                 }
 
                 call Sniffles.Sniffles {
@@ -259,7 +265,8 @@ workflow CallVariants {
                     ref_fasta_fai = ref_fasta_fai,
                     prefix = prefix,
                     tandem_repeat_bed = tandem_repeat_bed,
-                    is_ccs = true
+                    is_ccs = true,
+                    zones = arbitrary.zones
             }
             call VariantUtils.ZipAndIndexVCF as ZipAndIndexPBSV {input: vcf = PBSVslow.vcf }
 

--- a/wdl/tasks/CallVariantsPBCLR.wdl
+++ b/wdl/tasks/CallVariantsPBCLR.wdl
@@ -52,6 +52,8 @@ workflow CallVariants {
         tandem_repeat_bed: "BED file containing TRF finder (e.g. http://hgdownload.soe.ucsc.edu/goldenPath/hg38/bigZips/hg38.trf.bed.gz)"
     }
 
+    call Utils.RandomZoneSpewer as arbitrary {input: num_of_zones = 3}
+
     ######################################################################
     # Block for small variants handling
     ######################################################################
@@ -86,7 +88,8 @@ workflow CallVariants {
                         ref_fasta_fai = ref_fasta_fai,
                         prefix = prefix,
                         tandem_repeat_bed = tandem_repeat_bed,
-                        is_ccs = false
+                        is_ccs = false,
+                        zones = arbitrary.zones
                 }
 
                 call Sniffles.Sniffles {
@@ -139,7 +142,8 @@ workflow CallVariants {
                     ref_fasta_fai = ref_fasta_fai,
                     prefix = prefix,
                     tandem_repeat_bed = tandem_repeat_bed,
-                    is_ccs = false
+                    is_ccs = false,
+                    zones = arbitrary.zones
             }
             call VariantUtils.ZipAndIndexVCF as ZipAndIndexPBSV {input: vcf = PBSVslow.vcf }
 

--- a/wdl/tasks/Clair.wdl
+++ b/wdl/tasks/Clair.wdl
@@ -20,6 +20,8 @@ task Clair {
         String? chr
         String preset
 
+        String zones
+
         RuntimeAttr? runtime_attr_override
     }
 
@@ -93,6 +95,7 @@ task Clair {
         cpu:                    select_first([runtime_attr.cpu_cores,         default_attr.cpu_cores])
         memory:                 select_first([runtime_attr.mem_gb,            default_attr.mem_gb]) + " GiB"
         disks: "local-disk " +  select_first([runtime_attr.disk_gb,           default_attr.disk_gb]) + " HDD"
+        zones: zones
         bootDiskSizeGb:         select_first([runtime_attr.boot_disk_gb,      default_attr.boot_disk_gb])
         preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
         maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])

--- a/wdl/tasks/ONTPepper.wdl
+++ b/wdl/tasks/ONTPepper.wdl
@@ -22,7 +22,16 @@ task Pepper {
         Int threads
         Int memory
 
+        String zones = "us-central1-b us-central1-c"
+
         RuntimeAttr? runtime_attr_override
+    }
+
+    parameter_meta {
+        # when running large scale workflows, we sometimes see errors like the following
+        #   A resource limit has delayed the operation: generic::resource_exhausted: allocating: selecting resources: selecting region and zone:
+        #   no available zones: 2763 LOCAL_SSD_TOTAL_GB (738/30000 available) usage too high
+        zones: "select which zone (GCP) to run this task"
     }
 
     Int bam_sz = ceil(size(bam, "GB"))
@@ -105,6 +114,7 @@ task Pepper {
         cpu:                    select_first([runtime_attr.cpu_cores,         default_attr.cpu_cores])
         memory:                 select_first([runtime_attr.mem_gb,            default_attr.mem_gb]) + " GiB"
         disks: "local-disk " +  select_first([runtime_attr.disk_gb,           default_attr.disk_gb]) + " HDD"
+        zones: zones
         bootDiskSizeGb:         select_first([runtime_attr.boot_disk_gb,      default_attr.boot_disk_gb])
         preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
         maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])

--- a/wdl/tasks/PBSV.wdl
+++ b/wdl/tasks/PBSV.wdl
@@ -12,6 +12,8 @@ workflow RunPBSV {
         File ref_fasta_fai
         String prefix
 
+        String zones
+
         File? tandem_repeat_bed
     }
 
@@ -26,7 +28,8 @@ workflow RunPBSV {
             ref_fasta         = ref_fasta,
             ref_fasta_fai     = ref_fasta_fai,
             tandem_repeat_bed = tandem_repeat_bed,
-            prefix            = prefix
+            prefix            = prefix,
+            zones             = zones
     }
 
     call Call {
@@ -35,7 +38,8 @@ workflow RunPBSV {
             ref_fasta     = ref_fasta,
             ref_fasta_fai = ref_fasta_fai,
             ccs           = is_ccs,
-            prefix        = prefix
+            prefix        = prefix,
+            zones         = zones
     }
 
     output {
@@ -52,6 +56,7 @@ task Discover {
         File? tandem_repeat_bed
         String? chr
         String prefix
+        String zones
         RuntimeAttr? runtime_attr_override
     }
 
@@ -101,6 +106,7 @@ task Discover {
         cpu:                    select_first([runtime_attr.cpu_cores,         default_attr.cpu_cores])
         memory:                 select_first([runtime_attr.mem_gb,            default_attr.mem_gb]) + " GiB"
         disks: "local-disk " +  select_first([runtime_attr.disk_gb,           default_attr.disk_gb]) + " HDD"
+        zones: zones
         bootDiskSizeGb:         select_first([runtime_attr.boot_disk_gb,      default_attr.boot_disk_gb])
         preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
         maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])
@@ -115,6 +121,7 @@ task Call {
         File ref_fasta_fai
         Boolean ccs
         String prefix
+        String zones
         RuntimeAttr? runtime_attr_override
     }
 
@@ -161,6 +168,7 @@ task Call {
         memory:                 select_first([runtime_attr.mem_gb,            default_attr.mem_gb]) + " GiB"
         disks: "local-disk " +  select_first([runtime_attr.disk_gb,           default_attr.disk_gb]) + " HDD"
         bootDiskSizeGb:         select_first([runtime_attr.boot_disk_gb,      default_attr.boot_disk_gb])
+        zones: zones
         preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
         maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])
         docker:                 select_first([runtime_attr.docker,            default_attr.docker])


### PR DESCRIPTION
To avoid issues like #324  due to zone-specific resource bottlenecks.

The downside, as usual, is cost increase due to inter-zone data transfer.