### PR TITLE
Significantly reduce NanoPlotFromBam wall-clock time

### DIFF
--- a/docker/lr-nanoplot/Dockerfile
+++ b/docker/lr-nanoplot/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.9-buster
+
+ARG sha=e0028d85ec9e61f8c96bea240ffca65b713e3385
+RUN cd /opt/ && \
+    git clone https://github.com/wdecoster/NanoPlot.git && \
+    cd NanoPlot && git checkout ${sha} && \
+    pip install -e .

--- a/docker/lr-nanoplot/Makefile
+++ b/docker/lr-nanoplot/Makefile
@@ -1,0 +1,13 @@
+IMAGE_NAME = lr-nanoplot
+VERSION = 1.40.0-1
+TAG1 = us.gcr.io/broad-dsp-lrma/$(IMAGE_NAME):$(VERSION)
+TAG2 = us.gcr.io/broad-dsp-lrma/$(IMAGE_NAME):latest
+
+all: build push
+
+build:
+	docker build -t $(TAG1) -t $(TAG2) .
+
+push:
+	docker push $(TAG1)
+	docker push $(TAG2)

--- a/wdl/tasks/NanoPlot.wdl
+++ b/wdl/tasks/NanoPlot.wdl
@@ -167,10 +167,12 @@ task NanoPlotFromBam {
         RuntimeAttr? runtime_attr_override
     }
 
-    Int disk_size = 2*ceil(size(bam, "GB"))
+    Int disk_size = 2*ceil(size(bam, "GB")) + 10
 
     command <<<
         set -euxo pipefail
+
+        touch ~{bai} # avoid the warning bai is older than bam
 
         num_core=$(cat /proc/cpuinfo | awk '/^processor/{print $3}' | wc -l)
 
@@ -178,6 +180,8 @@ task NanoPlotFromBam {
                  -c orangered \
                  --N50 \
                  --tsv_stats \
+                 --no_supplementary \
+                 --verbose \
                  --bam "~{bam}"
 
         cat NanoStats.txt | \
@@ -233,19 +237,19 @@ task NanoPlotFromBam {
 
     #########################
     RuntimeAttr default_attr = object {
-        cpu_cores:          16,
-        mem_gb:             32,
+        cpu_cores:          8,
+        mem_gb:             24,
         disk_gb:            disk_size,
         boot_disk_gb:       10,
         preemptible_tries:  0,
         max_retries:        1,
-        docker:             "quay.io/biocontainers/nanoplot:1.35.5--pyhdfd78af_0"
+        docker:             "us.gcr.io/broad-dsp-lrma/lr-nanoplot:1.40.0-1"
     }
     RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
     runtime {
         cpu:                    select_first([runtime_attr.cpu_cores,         default_attr.cpu_cores])
         memory:                 select_first([runtime_attr.mem_gb,            default_attr.mem_gb]) + " GiB"
-        disks: "local-disk " +  select_first([runtime_attr.disk_gb,           default_attr.disk_gb]) + " HDD"
+        disks: "local-disk " +  select_first([runtime_attr.disk_gb,           default_attr.disk_gb]) + " LOCAL"
         bootDiskSizeGb:         select_first([runtime_attr.boot_disk_gb,      default_attr.boot_disk_gb])
         preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
         maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])


### PR DESCRIPTION
  * use a new docker which supports parallelization
  * drop supp alns

See https://github.com/wdecoster/NanoPlot/issues/306