### PR TITLE
update CallVariantsPBCCS with Sniffles2

### DIFF
--- a/docker/lr-sniffles2/Dockerfile
+++ b/docker/lr-sniffles2/Dockerfile
@@ -1,0 +1,21 @@
+FROM continuumio/miniconda3
+
+MAINTAINER Evie Wan
+
+# copy other resources
+COPY ./environment.yml /
+
+# install conda packages
+RUN conda env create -f /environment.yml && conda clean -a
+ENV PATH=/opt/conda/envs/lr-sniffles2/bin/:/root/google-cloud-sdk/bin/:${PATH}
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/conda/envs/lr-sniffles2/lib/
+
+RUN apt-get -y update \
+	&& apt-get -y install git make cmake protobuf-compiler gcc g++ zlib1g-dev libcurl4-openssl-dev libbz2-dev tree python3-pip liblzma-dev wget curl \
+	&& apt-get clean
+
+# install gsutil
+RUN curl https://sdk.cloud.google.com | bash
+
+
+RUN echo "source activate lr-sniffles2" > ~/.bashrc

--- a/docker/lr-sniffles2/Makefile
+++ b/docker/lr-sniffles2/Makefile
@@ -1,0 +1,13 @@
+VERSION = 2.0.6
+
+TAG1 = us.gcr.io/broad-dsp-lrma/lr-sniffles2:$(VERSION)
+TAG2 = us.gcr.io/broad-dsp-lrma/lr-sniffles2:latest
+
+all: build push
+
+build:
+	docker build -t $(TAG1) -t $(TAG2) .
+
+push:
+	docker push $(TAG1)
+	docker push $(TAG2)

--- a/docker/lr-sniffles2/environment.yml
+++ b/docker/lr-sniffles2/environment.yml
@@ -1,0 +1,10 @@
+name: lr-sniffles2
+channels:
+  - bioconda
+  - conda-forge
+  - defaults
+dependencies:
+  - sniffles=2.0.6
+  - pysam=0.19.1
+
+prefix: /opt/conda/envs/lr-sniffles2

--- a/wdl/tasks/CallVariantsPBCCS.wdl
+++ b/wdl/tasks/CallVariantsPBCCS.wdl
@@ -41,6 +41,7 @@ workflow CallVariants {
     parameter_meta {
         fast_less_sensitive_sv:  "to trade less sensitive SV calling for faster speed"
         tandem_repeat_bed:       "BED file containing TRF finder for better PBSV calls (e.g. http://hgdownload.soe.ucsc.edu/goldenPath/hg38/bigZips/hg38.trf.bed.gz)"
+        minsvlen:       "Minimum SV length in bp (default: 35)"
 
         call_small_vars_on_mitochondria: "if false, will not attempt to call variants on mitochondria"
         sites_vcf:     "for use with Clair"

--- a/wdl/tasks/CallVariantsPBCCS.wdl
+++ b/wdl/tasks/CallVariantsPBCCS.wdl
@@ -242,7 +242,7 @@ workflow CallVariants {
 
             call VariantUtils.ZipAndIndexVCF as ZipAndIndexPBSV {input: vcf = PBSVslow.vcf }
 
-            call Sniffles2.sample_sv as sample_snf_slow {
+            call Sniffles2.SampleSV as sample_snf_slow {
                 input:
                     bam    = bam,
                     bai    = bai,

--- a/wdl/tasks/CallVariantsPBCCS.wdl
+++ b/wdl/tasks/CallVariantsPBCCS.wdl
@@ -241,7 +241,7 @@ workflow CallVariants {
 
             call VariantUtils.ZipAndIndexVCF as ZipAndIndexPBSV {input: vcf = PBSVslow.vcf }
 
-            call Sniffles2.SampleSV as sample_snf_slow {
+            call Sniffles2.SampleSV as Sniffles2SV {
                 input:
                     bam    = bam,
                     bai    = bai,
@@ -250,18 +250,17 @@ workflow CallVariants {
                     prefix = prefix
             }
 
-            call VariantUtils.ZipAndIndexVCF as ZipAndIndexVCF_slow {
+            call VariantUtils.ZipAndIndexVCF as ZipAndIndexSnifflesVCF {
                 input:
-                    vcf = sample_snf_slow.vcf
+                    vcf = Sniffles2SV.vcf
             }
         }
     }
 
     output {
-        File? sniffles_vcf = sample_snf_slow.vcf
-        File? sniffles_vcfgz = ZipAndIndexVCF_slow.vcfgz
-        File? sniffles_tbi = ZipAndIndexVCF_slow.tbi
-        File? sniffles_snf = sample_snf_slow.snf
+        File? sniffles_vcf = ZipAndIndexSnifflesVCF.vcfgz
+        File? sniffles_tbi = ZipAndIndexSnifflesVCF.tbi
+        File? sniffles_snf = Sniffles2SV.snf
         File? pbsv_vcf = select_first([MergePBSVVCFs.vcf, ZipAndIndexPBSV.vcfgz])
         File? pbsv_tbi = select_first([MergePBSVVCFs.tbi, ZipAndIndexPBSV.tbi])
 

--- a/wdl/tasks/CallVariantsPBCCS.wdl
+++ b/wdl/tasks/CallVariantsPBCCS.wdl
@@ -9,7 +9,7 @@ import "CCSPepper.wdl"
 
 workflow CallVariants {
     meta {
-        descrition: "A workflow for calling small and/or structural variants from an aligned CCS BAM file."
+        description: "A workflow for calling small and/or structural variants from an aligned CCS BAM file."
     }
     input {
         File bam
@@ -18,11 +18,9 @@ workflow CallVariants {
         String prefix
         String sample_id
 
-
         File ref_fasta
         File ref_fasta_fai
         File ref_dict
-
 
         Boolean call_svs
         Boolean fast_less_sensitive_sv
@@ -255,8 +253,6 @@ workflow CallVariants {
                 input:
                     vcf = sample_snf_slow.vcf
             }
-
-
         }
     }
 

--- a/wdl/tasks/Sniffles2.wdl
+++ b/wdl/tasks/Sniffles2.wdl
@@ -17,7 +17,7 @@ workflow Sniffles2 {
         String sample_id}
 
     scatter (pair in zip(sampleBAMs, sampleBai)) {
-        call sample_sv {
+        call SampleSV {
                 input:
                     bam = pair.left,
                     bai = pair.right,
@@ -27,18 +27,18 @@ workflow Sniffles2 {
                 }
          }
 
-    call merge_call { input: snfs = sample_sv.snf}
+    call MergeCall { input: snfs = SampleSV.snf}
 
 
     output {
-         Array[File] single_snf = sample_sv.snf
-         File multisample_vcf = merge_call.vcf
+         Array[File] single_snf = SampleSV.snf
+         File multisample_vcf = MergeCall.vcf
         }
 }
 
 
 
-task sample_sv {
+task SampleSV {
 
     input {
         File bam
@@ -55,7 +55,7 @@ task sample_sv {
         bai:              "index accompanying the BAM"
         minsvlen:         "minimum SV length in bp. Default 35"
         chr:              "chr on which to call variants"
-        sample_id:         "Sample ID"
+        sample_id:        "Sample ID"
         prefix:           "prefix for output"
     }
 
@@ -104,14 +104,14 @@ task sample_sv {
 }
 
 
-task merge_call {
+task MergeCall {
     input {
         Array[File] snfs
         RuntimeAttr? runtime_attr_override
     }
 
     parameter_meta {
-        snfs: "snf files"
+        snfs: ".snf files"
 }
 
     command <<<

--- a/wdl/tasks/Sniffles2.wdl
+++ b/wdl/tasks/Sniffles2.wdl
@@ -1,0 +1,150 @@
+version 1.0
+
+
+import "Structs.wdl"
+
+# "This workflow calls SV candidates using Sniffles2 population mode.
+# 1) Call SV candidates and create .snf file for each sample
+#  2) Combined calling using multiple .snf files into a single .vcf"
+
+workflow Sniffles2 {
+
+    input {
+        Array[File] sampleBAMs
+        Array[File] sampleBai
+        Int minsvlen
+        String prefix
+        String sample_id}
+
+    scatter (pair in zip(sampleBAMs, sampleBai)) {
+        call sample_sv {
+                input:
+                    bam = pair.left,
+                    bai = pair.right,
+                    minsvlen = minsvlen,
+                    prefix = prefix,
+                    sample_id = sample_id
+                }
+         }
+
+    call merge_call { input: snfs = sample_sv.snf}
+
+
+    output {
+         Array[File] single_snf = sample_sv.snf
+         File multisample_vcf = merge_call.vcf
+        }
+}
+
+
+
+task sample_sv {
+
+    input {
+        File bam
+        File bai
+        Int minsvlen
+        String? chr
+        String sample_id
+        String prefix
+        RuntimeAttr? runtime_attr_override
+    }
+
+    parameter_meta {
+        bam:              "input BAM from which to call SVs"
+        bai:              "index accompanying the BAM"
+        minsvlen:         "minimum SV length in bp. Default 35"
+        chr:              "chr on which to call variants"
+        sample_id:         "Sample ID"
+        prefix:           "prefix for output"
+    }
+
+    Int cpus = 8
+    Int disk_size = 2*ceil(size([bam, bai], "GB"))
+    String fileoutput = if defined(chr) then "~{prefix}.~{chr}.sniffles.snf" else "~{prefix}.sniffles.snf"
+    String vcf_output = if defined(chr) then "~{prefix}.~{chr}.sniffles.vcf" else "~{prefix}.sniffles.vcf"
+
+    command <<<
+        set -x
+
+        sniffles -t ~{cpus} \
+                 -i ~{bam} \
+                 --minsvlen ~{minsvlen} \
+                 --sample-id ~{sample_id} \
+                 --vcf ~{vcf_output} \
+                 --snf ~{fileoutput}
+        tree
+    >>>
+
+    output {
+        File snf = "~{fileoutput}"
+        File vcf = "~{vcf_output}"
+    }
+
+    #########################
+    RuntimeAttr default_attr = object {
+        cpu_cores:          cpus,
+        mem_gb:             46,
+        disk_gb:            disk_size,
+        boot_disk_gb:       10,
+        preemptible_tries:  3,
+        max_retries:        2,
+        docker:             "us.gcr.io/broad-dsp-lrma/lr-sniffles2:2.0.6"
+    }
+    RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
+    runtime {
+        cpu:                    select_first([runtime_attr.cpu_cores,         default_attr.cpu_cores])
+        memory:                 select_first([runtime_attr.mem_gb,            default_attr.mem_gb]) + " GiB"
+        disks: "local-disk " +  select_first([runtime_attr.disk_gb,           default_attr.disk_gb]) + " HDD"
+        bootDiskSizeGb:         select_first([runtime_attr.boot_disk_gb,      default_attr.boot_disk_gb])
+        preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
+        maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])
+        docker:                 select_first([runtime_attr.docker,            default_attr.docker])
+    }
+}
+
+
+task merge_call {
+    input {
+        Array[File] snfs
+        RuntimeAttr? runtime_attr_override
+    }
+
+    parameter_meta {
+        snfs: "snf files"
+}
+
+    command <<<
+        set -x
+        sniffles --input ~{sep=" " snfs} \
+        --vcf multisample.vcf
+        tree
+    >>>
+
+    output {
+        File vcf = "multisample.vcf" }
+
+    Int cpus = 8
+    Int disk_size = 3*ceil(size(snfs, "GB"))
+                                                                                                                                                                                                                                                                                                                                                                                                                                   #########################
+    RuntimeAttr default_attr = object {
+        cpu_cores:          cpus,
+        mem_gb:             46,
+        disk_gb:            disk_size,
+        boot_disk_gb:       10,
+        preemptible_tries:  3,
+        max_retries:        2,
+        docker:             "us.gcr.io/broad-dsp-lrma/lr-sniffles2:2.0.6"
+    }
+    RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
+    runtime {
+        cpu:                    select_first([runtime_attr.cpu_cores,         default_attr.cpu_cores])
+        memory:                 select_first([runtime_attr.mem_gb,            default_attr.mem_gb]) + " GiB"
+        disks: "local-disk " +  select_first([runtime_attr.disk_gb,           default_attr.disk_gb]) + " HDD"
+        bootDiskSizeGb:         select_first([runtime_attr.boot_disk_gb,      default_attr.boot_disk_gb])
+        preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
+        maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])
+        docker:                 select_first([runtime_attr.docker,            default_attr.docker])
+    }
+
+}


### PR DESCRIPTION
Update CallVariantsPBCCS to call variants across the whole genome with Sniffles2. Sniffles2 only calls variants across the genome and not per-chromosome since it's not clear how to merge .snf files. 