### PR TITLE
Send nightly status message to #lrma-repos, rather than #lrma

### DIFF
--- a/.github/workflows/ci_nightly.yml
+++ b/.github/workflows/ci_nightly.yml
@@ -68,7 +68,7 @@ jobs:
       env:
         SLACK_MESSAGE: 'Nightly test of the main branch failed.'
         SLACK_COLOR: '#DF5A49'
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_NIGHTLY }}
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         SLACK_ICON: https://github.com/broadinstitute/long-read-pipelines/blob/main/.github/workflows/dnabad.png?raw=true
         SLACK_USERNAME: long-read-pipelines
 
@@ -79,6 +79,6 @@ jobs:
       env:
         SLACK_MESSAGE: 'Nightly test of the main branch successful!'
         SLACK_COLOR: '#50D9C9'
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_NIGHTLY }}
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         SLACK_ICON: https://github.com/broadinstitute/long-read-pipelines/blob/main/.github/workflows/dnagood.png?raw=true
         SLACK_USERNAME: long-read-pipelines


### PR DESCRIPTION
This PR updates two lines in our ci-nightly.yml Github action, directing the 3am status on the nightly test suite to #lrma-repos rather than #lrma.