### PR TITLE
Add TRGT Special-purpose caller

### DIFF
--- a/docker/lr-trgt/Dockerfile
+++ b/docker/lr-trgt/Dockerfile
@@ -1,0 +1,11 @@
+FROM us.gcr.io/broad-dsp-lrma/lr-pb:0.1.40
+
+RUN wget "http://github.com/PacificBiosciences/trgt/releases/download/v0.4.0/trgt-v0.4.0-linux_x86_64.gz" -O "trgt.gz" && \
+        gunzip trgt.gz && \
+        chmod 777 trgt && \
+        mv trgt /usr/bin/
+
+RUN wget "http://github.com/PacificBiosciences/trgt/releases/download/v0.4.0/trvz-v0.4.0-linux_x86_64.gz" -O "trvz.gz" && \
+        gunzip trvz.gz && \
+        chmod 777 trvz && \
+        mv trvz /usr/bin/

--- a/docker/lr-trgt/Makefile
+++ b/docker/lr-trgt/Makefile
@@ -1,0 +1,15 @@
+VERSION = 0.4.0
+TAG1 = us.gcr.io/broad-dsp-lrma/lr-trgt:$(VERSION)
+TAG2 = us.gcr.io/broad-dsp-lrma/lr-trgt:latest
+
+all: build push
+
+build:
+        docker build -t $(TAG1) -t $(TAG2) .
+
+build_no_cache:
+        docker build --no-cache -t $(TAG1) -t $(TAG2) .
+
+push:
+        docker push $(TAG1)
+        docker push $(TAG2)

--- a/wdl/pipelines/PacBio/VariantCalling/PBCCSWholeGenome.wdl
+++ b/wdl/pipelines/PacBio/VariantCalling/PBCCSWholeGenome.wdl
@@ -4,6 +4,7 @@ import "../../../tasks/Utility/PBUtils.wdl" as PB
 import "../../../tasks/Utility/Utils.wdl" as Utils
 import "../../../tasks/VariantCalling/CallVariantsPBCCS.wdl" as VAR
 import "../../../tasks/Utility/Finalize.wdl" as FF
+import "../../../tasks/VariantCalling/TRGT.wdl" as TRGT
 
 import "../../../tasks/QC/SampleLevelAlignedMetrics.wdl" as COV
 
@@ -31,6 +32,9 @@ workflow PBCCSWholeGenome {
         run_dv_pepper_analysis:  "to turn on DV-Pepper analysis or not (non-trivial increase in cost and runtime)"
         ref_scatter_interval_list_locator: "A file holding paths to interval_list files; needed only when running DV-Pepper"
         ref_scatter_interval_list_ids:     "A file that gives short IDs to the interval_list files; needed only when running DV-Pepper"
+
+        call_trs: "whether to call TRs"
+        trs_catalog: "optionally specify a non-default catalog to use when calling TRs, for use with TRGT"
     }
 
     input {
@@ -58,6 +62,9 @@ workflow PBCCSWholeGenome {
         Int? dvp_memory = 128
         File? ref_scatter_interval_list_locator
         File? ref_scatter_interval_list_ids
+
+        Boolean call_trs = true
+        File? trs_catalog
     }
 
     Map[String, String] ref_map = read_map(ref_map_file)
@@ -167,6 +174,17 @@ workflow PBCCSWholeGenome {
         }
     }
 
+    if call_trs {
+        call TRGT.runTRGT {
+            input:
+                input_bam         = bam,
+                input_bam_bai     = bai,
+                output_gs_path    = svdir,
+                ref_fasta         = ref_map['fasta'],
+                ref_fasta_fai     = ref_map['fai'],
+                ref_dict          = ref_map['dict']
+    }
+
     output {
         File aligned_bam = FinalizeBam.gcs_path
         File aligned_bai = FinalizeBai.gcs_path
@@ -205,5 +223,8 @@ workflow PBCCSWholeGenome {
         File? dvp_g_tbi = FinalizeDVPepperGTbi.gcs_path
         File? dvp_phased_vcf = FinalizeDVPEPPERPhasedVcf.gcs_path
         File? dvp_phased_tbi = FinalizeDVPEPPERPhasedTbi.gcs_path
+
+        File? trgt_vcf = runTRGT.trgt_output_vcf
+        File? trgt_bam = runTRGT.trgt_output_bam
     }
 }

--- a/wdl/tasks/VariantCalling/TRGT.wdl
+++ b/wdl/tasks/VariantCalling/TRGT.wdl
@@ -1,0 +1,90 @@
+version 1.0
+
+workflow runTRGT {
+
+  meta {
+    description: "Uses TRGT to size TRs in a bam file."
+  }
+
+  input {
+    File input_bam
+    File input_bam_bai
+    String basename = basename(input_bam, ".bam")
+    String output_gs_path
+    File ref_dict
+    File ref_fasta
+    File ref_fasta_index
+    File repeatCatalog = "https://zuchnerlab.s3.amazonaws.com/RepeatExpansions/TRGT/adotto_TRregions_TRGTFormatWithFlankingSeq_v1.0.bed"
+
+    #Optional runtime arguments
+    RuntimeAttr? runtime_attr_override
+  }
+
+  call processWithTRGT {
+    input:
+      input_bam = input_bam,
+      input_bam_bai = input_bam_bai,
+      basename = basename,
+      ref_fasta = ref_fasta,
+      ref_fasta_index = ref_fasta_index,
+      ref_dict = ref_dict,
+      repeatCatalog = repeatCatalog,
+      runtime_attr_override = runtime_attr_override
+  }
+
+  output {
+    File trgt_output_vcf = processWithTRGT.trgt_output_vcf
+    File trgt_output_bam = processWithTRGT.trgt_output_bam
+  }
+}
+
+task processWithTRGT {
+  input {
+    File input_bam
+    File input_bam_bai
+    String basename
+    File ref_fasta
+    File ref_fasta_index
+    File ref_dict
+    File repeatCatalog
+
+    RuntimeAttr? runtime_attr_override
+
+  }
+  #########################
+  RuntimeAttr default_attr = object {
+      cpu_cores:          4,
+      mem_gb:             16,
+      disk_gb:            500,
+      boot_disk_gb:       10,
+      preemptible_tries:  3,
+      max_retries:        1,
+      docker:             "public.ecr.aws/s5z5a3q9/lr-trgt:0.4.0"
+  }
+  RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
+
+  meta {
+    description: "Uses TRGT to size TRs in a bam file."
+  }
+
+  command <<<
+    set -euo pipefail
+    trgt --genome ~{ref_fasta} --repeats ~{repeatCatalog} --reads ~{input_bam} --threads ~{runtime_attr.cpu_cores} --output-prefix ~{basename}_trgt
+
+  >>>
+
+  output {
+    File trgt_output_vcf = "~{basename}_trgt.vcf.gz"
+    File trgt_output_bam = "~{basename}_trgt.spanning.bam"
+  }
+
+  runtime {
+      cpu:                    select_first([runtime_attr.cpu_cores,         default_attr.cpu_cores])
+      memory:                 select_first([runtime_attr.mem_gb,            default_attr.mem_gb]) + " GiB"
+      disks: "local-disk " +  select_first([runtime_attr.disk_gb,           default_attr.disk_gb]) + " HDD"
+      bootDiskSizeGb:         select_first([runtime_attr.boot_disk_gb,      default_attr.boot_disk_gb])
+      preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
+      maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])
+      docker:                 select_first([runtime_attr.docker,            default_attr.docker])
+  }
+}


### PR DESCRIPTION
I would like to propose the incorporation of TRGT as a special-purpose caller of tandem repeat genotypes into the PacBio CCS variant calling workflow. I have added a task and sub-workflow for TRGT, details of how to create the docker image used for its run, and incorporated it into the PBCCSWholeGenome.wdl pipeline. 

TRGT requires an input specification file. I am currently hosting the file used on the Phase 1 data and link to it in the TRGT.wdl file. This should be moved to a gcs bucket for better performance in production. 