### PR TITLE
Fix dockstore validator step in yml to insure action fails if step fails

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -93,6 +93,6 @@ workflows:
 - name: ONTFlowcellFromMultipleBasecalls
   subclass: wdl
   primaryDescriptorPath: /wdl/pipelines/ONT/Preprocessing/ONTFlowcellFromMultipleBasecalls.wdl
-- name CleanupIntermediate
+- name: CleanupIntermediate
   subclass: wdl
   primaryDescriptorPath: /wdl/pipelines/TechAgnostic/Utility/CleanupIntermediate.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -95,4 +95,4 @@ workflows:
   primaryDescriptorPath: /wdl/pipelines/ONT/Preprocessing/ONTFlowcellFromMultipleBasecalls.wdl
 - name: CleanupIntermediate
   subclass: wdl
-  primaryDescriptorPath: /wdl/pipelines/TechAgnostic/Utility/CleanupIntermediate.wdl
+  primaryDescriptorPath: /wdl/pipelines/TechAgnostic/Utility/CleanupIntermediate.

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -93,6 +93,6 @@ workflows:
 - name: ONTFlowcellFromMultipleBasecalls
   subclass: wdl
   primaryDescriptorPath: /wdl/pipelines/ONT/Preprocessing/ONTFlowcellFromMultipleBasecalls.wdl
-- name: CleanupIntermediate
+- name CleanupIntermediate
   subclass: wdl
-  primaryDescriptorPath: /wdl/pipelines/TechAgnostic/Utility/CleanupIntermediate.
+  primaryDescriptorPath: /wdl/pipelines/TechAgnostic/Utility/CleanupIntermediate.wdl

--- a/.github/workflows/validate_dockstore_yaml.yml
+++ b/.github/workflows/validate_dockstore_yaml.yml
@@ -33,7 +33,10 @@ jobs:
 
             - name: Validate dockstore.yml
               run: |
-                set -euxo pipefail
                 export PATH=~/bin:$PATH
                 dockstore --upgrade
                 dockstore yaml validate --path . 
+                if [ $? -ne 0 ]; then
+                  echo "Dockstore validation failed."
+                  exit 1
+                fi

--- a/.github/workflows/validate_dockstore_yaml.yml
+++ b/.github/workflows/validate_dockstore_yaml.yml
@@ -22,7 +22,7 @@ jobs:
             - name: Install dockstore cli
               run: |
                 mkdir -p ~/bin
-                curl -L -o ~/bin/dockstore https://github.com/dockstore/dockstore-cli/releases/download/1.13.1/dockstore
+                curl -L -o ~/bin/dockstore https://github.com/dockstore/dockstore-cli/releases/download/1.14.0/dockstore
                 chmod +x ~/bin/dockstore
                 export PATH=~/bin:$PATH
                 
@@ -35,5 +35,6 @@ jobs:
               run: |
                 set -euxo pipefail
                 export PATH=~/bin:$PATH
+                dockstore --upgrade
                 dockstore yaml validate --path . 2>&1 | tee dockstore_result.txt
                 if grep -q "error" dockstore_result.txt ; then exit 1 ; fi

--- a/.github/workflows/validate_dockstore_yaml.yml
+++ b/.github/workflows/validate_dockstore_yaml.yml
@@ -7,11 +7,11 @@ jobs:
             - name: Checkout branch
               uses: actions/checkout@v3
 
-            - name: Setup Java 11
+            - name: Setup Java 17
               uses: actions/setup-java@v2
               with:
                 distribution: 'temurin'
-                java-version: '11'
+                java-version: '17'
 
             - name: Cache node_modules
               uses: actions/cache@v2

--- a/.github/workflows/validate_dockstore_yaml.yml
+++ b/.github/workflows/validate_dockstore_yaml.yml
@@ -36,7 +36,7 @@ jobs:
                 export PATH=~/bin:$PATH
 
                 validation_output=$(dockstore yaml validate --path .)
-
+                echo "$validation_output"
                 if [[ $validation_output == *"Your .dockstore.yml has the following errors"* ]]; then
                   echo "Dockstore validation failed."
                   exit 1

--- a/.github/workflows/validate_dockstore_yaml.yml
+++ b/.github/workflows/validate_dockstore_yaml.yml
@@ -34,9 +34,10 @@ jobs:
             - name: Validate dockstore.yml
               run: |
                 export PATH=~/bin:$PATH
-                dockstore --upgrade
-                dockstore yaml validate --path . 
-                if [ $? -ne 0 ]; then
+
+                validation_output=$(dockstore yaml validate --path .)
+
+                if [[ $validation_output == *"Your .dockstore.yml has the following errors"* ]]; then
                   echo "Dockstore validation failed."
                   exit 1
                 fi

--- a/.github/workflows/validate_dockstore_yaml.yml
+++ b/.github/workflows/validate_dockstore_yaml.yml
@@ -36,5 +36,4 @@ jobs:
                 set -euxo pipefail
                 export PATH=~/bin:$PATH
                 dockstore --upgrade
-                dockstore yaml validate --path . 2>&1 | tee dockstore_result.txt
-                if grep -q "error" dockstore_result.txt ; then exit 1 ; fi
+                dockstore yaml validate --path . 

--- a/.github/workflows/validate_dockstore_yaml.yml
+++ b/.github/workflows/validate_dockstore_yaml.yml
@@ -37,7 +37,8 @@ jobs:
 
                 validation_output=$(dockstore yaml validate --path .)
                 echo "$validation_output"
-                if [[ $validation_output == *"Your .dockstore.yml has the following errors"* ]]; then
+                                
+                if [[ $validation_output == *"Your .dockstore.yml has the following errors"* || $validation_output == *"Your .dockstore.yml is invalid"* ]]; then
                   echo "Dockstore validation failed."
                   exit 1
                 fi

--- a/.github/workflows/validate_dockstore_yaml.yml
+++ b/.github/workflows/validate_dockstore_yaml.yml
@@ -33,6 +33,7 @@ jobs:
 
             - name: Validate dockstore.yml
               run: |
+                set -euxo pipefail
                 export PATH=~/bin:$PATH
                 dockstore yaml validate --path . 2>&1 | tee dockstore_result.txt
                 if grep -q "error" dockstore_result.txt ; then exit 1 ; fi


### PR DESCRIPTION
updated dockster cli version
added an additional error message to be used when manually checking dockstore cli validation results for error

(note: Checking results manually is necessary because dockstore returns a 0 even when validation fails)