### PR TITLE
Increase Maximum Cycle Value for Base Recalibrator 

### DIFF
--- a/wdl/pipelines/ILMN/Alignment/SRFlowcell.wdl
+++ b/wdl/pipelines/ILMN/Alignment/SRFlowcell.wdl
@@ -191,7 +191,9 @@ workflow SRFlowcell {
                 known_sites_vcf = ref_map["known_sites_vcf"],
                 known_sites_index = ref_map["known_sites_index"],
 
-                prefix = SM + ".baseRecalibratorReport"
+                prefix = SM + ".baseRecalibratorReport",
+                maximum_cycle_value = 1000 
+
         }
 
         call SRUTIL.ApplyBQSR as t_010_ApplyBQSR {

--- a/wdl/tasks/Utility/SRUtils.wdl
+++ b/wdl/tasks/Utility/SRUtils.wdl
@@ -399,6 +399,7 @@ task BaseRecalibrator {
         File known_sites_index
 
         String prefix
+        Int maximum_cycle_value = 1000
 
         RuntimeAttr? runtime_attr_override
     }
@@ -425,7 +426,9 @@ task BaseRecalibrator {
             -I ~{input_bam} \
             --use-original-qualities \
             -O ~{prefix}.txt \
-            --known-sites ~{known_sites_vcf}
+            --known-sites ~{known_sites_vcf} \
+            --maximum-cycle-value ~{maximum_cycle_value} 
+
 
     }
     #########################


### PR DESCRIPTION
**DRAFT** **(Please Do Not Merge)**: This PR addresses an issue where the BaseRecalibrator task encountered a cycle value limit error. The maximum cycle value has been increased to 1000 to accommodate larger cycle numbers in the data, preventing related errors and ensuring smoother processing. 
