### PR TITLE
Updates for Malaria pipelines: human read decontamination and WDLs for on-prem Malaria pipelines

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -159,3 +159,9 @@ workflows:
 - name: BackupWorkspace
   subclass: wdl
   primaryDescriptorPath: /wdl/pipelines/TechAgnostic/Utility/BackupWorkspace.wdl
+- name: BroadOnPremMalariaAlignmentAndVariantCalling
+  subclass: wdl
+  primaryDescriptorPath: /wdl/pipelines/BroadOnPremMalariaPipeline_1_Alignment_and_Variant_Calling.wdl
+- name: BroadOnPremMalariaJointCalling
+  subclass: wdl
+  primaryDescriptorPath: /wdl/pipelines/Z_One_Off_Analyses/BroadOnPremMalariaPipeline_2_JointVariantCalling.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -161,7 +161,7 @@ workflows:
   primaryDescriptorPath: /wdl/pipelines/TechAgnostic/Utility/BackupWorkspace.wdl
 - name: BroadOnPremMalariaAlignmentAndVariantCalling
   subclass: wdl
-  primaryDescriptorPath: /wdl/pipelines/BroadOnPremMalariaPipeline_1_Alignment_and_Variant_Calling.wdl
+  primaryDescriptorPath: /wdl/pipelines/Z_One_Off_Analyses/BroadOnPremMalariaPipeline_1_Alignment_and_Variant_Calling.wdl
 - name: BroadOnPremMalariaJointCalling
   subclass: wdl
   primaryDescriptorPath: /wdl/pipelines/Z_One_Off_Analyses/BroadOnPremMalariaPipeline_2_JointVariantCalling.wdl

--- a/docker/sr-alternate-tools/Dockerfile
+++ b/docker/sr-alternate-tools/Dockerfile
@@ -4,7 +4,29 @@ MAINTAINER Jonn Smith
 
 # Install required packages:
 RUN apt-get update -y && apt-get upgrade -y
-RUN apt-get install -y wget make g++ gcc git vim unzip bzip2 curl gnupg2 git-lfs parallel libc-dev ncurses-dev libcurl4-openssl-dev libssl-dev libbz2-dev liblzma-dev gcc python3-dev python3-setuptools
+RUN apt-get install -y --no-install-recommends \
+	wget \
+	make \
+	g++ \
+	gcc \
+	git \
+	vim \
+	unzip \
+	bzip2 \
+	curl \
+	gnupg2 \
+	git-lfs \
+	parallel \
+	libc-dev \
+	ncurses-dev \
+	libcurl4-openssl-dev \
+	libssl-dev \
+	libbz2-dev \
+	liblzma-dev \
+	gcc \
+	python3-dev \
+	python3-setuptools \
+	python3-pip 
 
 # install gsutil
 RUN apt-get --allow-releaseinfo-change update
@@ -50,4 +72,18 @@ RUN wget https://github.com/arq5x/bedtools2/releases/download/v2.31.1/bedtools-2
     make install && \
     cd .. && \
     rm -rf bedtools2 bedtools-2.31.1.tar.gz
+
+# Cleanup
+RUN rm -rf /tmp/* \
+           /var/tmp/* \
+           /var/cache/apt/* \
+           /var/lib/apt/lists/* \
+           /usr/share/man/?? \
+           /usr/share/man/??_* \
+           /root/.cache/pip \
+           /root/.cache/pip3 \
+           /var/lib/apt/lists/* && \
+	apt-get -qqy clean && \
+    apt-get -qqy autoclean && \
+    apt-get -qqy autoremove
 

--- a/docker/sr-alternate-tools/Dockerfile
+++ b/docker/sr-alternate-tools/Dockerfile
@@ -1,0 +1,53 @@
+FROM ubuntu:22.04
+
+MAINTAINER Jonn Smith
+
+# Install required packages:
+RUN apt-get update -y && apt-get upgrade -y
+RUN apt-get install -y wget make g++ gcc git vim unzip bzip2 curl gnupg2 git-lfs parallel libc-dev ncurses-dev libcurl4-openssl-dev libssl-dev libbz2-dev liblzma-dev gcc python3-dev python3-setuptools
+
+# install gsutil
+RUN apt-get --allow-releaseinfo-change update
+RUN curl https://sdk.cloud.google.com | bash
+
+# Setup crcmodc for gsutil:
+RUN pip3 uninstall -y crcmod && \
+    pip3 install --no-cache-dir -U crcmod
+
+# Install BWA-MEM2:
+RUN wget https://github.com/bwa-mem2/bwa-mem2/releases/download/v2.2.1/bwa-mem2-2.2.1_x64-linux.tar.bz2 && \
+    tar -xf bwa-mem2-2.2.1_x64-linux.tar.bz2 && \
+    mv bwa-mem2-2.2.1_x64-linux /opt/ && \
+    for f in $(find /opt/bwa-mem2-2.2.1_x64-linux/ -type f -name \*bwa-mem\* ) ; do ln -s $f /usr/local/bin/$(basename $f) ; done && \
+    rm bwa-mem2-2.2.1_x64-linux.tar.bz2 
+
+# Bowtie2:
+RUN wget https://github.com/BenLangmead/bowtie2/releases/download/v2.3.4.3/bowtie2-2.3.4.3-linux-x86_64.zip && \
+    unzip bowtie2-2.3.4.3-linux-x86_64.zip && \
+    mv bowtie2-2.3.4.3-linux-x86_64 /opt && \
+    for f in $( find /opt/bowtie2-2.3.4.3-linux-x86_64/ -type f -name \*bowtie\* ) ; do ln -s $f /usr/local/bin/$(basename $f) ; done && \
+    rm bowtie2-2.3.4.3-linux-x86_64.zip
+
+# Install samtools 1.11:
+#### Specific for google cloud support
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
+		&& curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - \
+		&& apt-get update -y \
+		&& apt-get install google-cloud-sdk -y
+
+# Get samtools source:
+RUN wget https://github.com/samtools/samtools/releases/download/1.11/samtools-1.11.tar.bz2 \
+		&& tar -xjf samtools-1.11.tar.bz2 \
+		&& cd samtools-1.11 \
+		&& ./configure \
+		&& make install
+RUN rm -rf /samtools-1.11 /samtools-1.11.tar.bz2
+
+# Bedtools:
+RUN wget https://github.com/arq5x/bedtools2/releases/download/v2.31.1/bedtools-2.31.1.tar.gz && \
+    tar -xf bedtools-2.31.1.tar.gz && \
+    cd bedtools2 && \
+    make install && \
+    cd .. && \
+    rm -rf bedtools2 bedtools-2.31.1.tar.gz
+

--- a/docker/sr-alternate-tools/Makefile
+++ b/docker/sr-alternate-tools/Makefile
@@ -1,0 +1,18 @@
+IMAGE_NAME = sr-alternate-tools
+VERSION = 0.0.1
+
+TAG1 = us.gcr.io/broad-dsp-lrma/$(IMAGE_NAME):$(VERSION)
+TAG2 = us.gcr.io/broad-dsp-lrma/$(IMAGE_NAME):latest
+
+all: | build push
+
+build:
+	docker build -t $(TAG1) -t $(TAG2) .
+
+build_no_cache:
+	docker build --no-cache -t $(TAG1) -t $(TAG2) .
+
+push:
+	docker push $(TAG1)
+	docker push $(TAG2)
+

--- a/wdl/deprecated/tasks/GATKBestPractice.wdl
+++ b/wdl/deprecated/tasks/GATKBestPractice.wdl
@@ -126,8 +126,7 @@ workflow GATKBestPraciceForLR {
             call Utils.SortSam as SortBamout {
                 input:
                     input_bam = HaplotypeCallerGATK4.bamout,
-                    output_bam_basename = output_prefix,
-                    compression_level = 2
+                    prefix = output_prefix,
             }
         }
 

--- a/wdl/pipelines/ILMN/Alignment/SRFlowcell.wdl
+++ b/wdl/pipelines/ILMN/Alignment/SRFlowcell.wdl
@@ -96,10 +96,8 @@ workflow SRFlowcell {
         call Utils.GetRawReadGroup as t_004_GetRawReadGroup { input: gcs_bam_path = select_first([bam]) }
     }
 
-    # OK, this is inefficient, but let's NOW extract our contaminated reads if we have the info.
-    # TODO: Move this into the sections above to make it more efficient.  Specifically where we convert bam -> fastq.
-    # TODO: Re-enable this section after decontamination is fixed.  The alignment based method with BWA-MEM doesn't work.  Not clear why, but this does seem somewhat inadequate (simplistic alignment-based strategies).
-    if (false && defined(contaminant_ref_map_file)) {
+    # Perform decontamination if we have the contaminant reference:
+    if (defined(contaminant_ref_map_file)) {
 
         # Call our sub-workflow for decontamination:
         # NOTE: We don't need to be too concerned with the finalization info.

--- a/wdl/pipelines/ILMN/Alignment/SRFlowcell.wdl
+++ b/wdl/pipelines/ILMN/Alignment/SRFlowcell.wdl
@@ -169,8 +169,7 @@ workflow SRFlowcell {
     call Utils.SortSam as t_009_SortAlignedDuplicateMarkedBam {
         input:
             input_bam = t_008_MarkDuplicates.bam,
-            output_bam_basename = SM + ".aligned.merged.markDuplicates.sorted",
-            compression_level = 2
+            prefix = SM + ".aligned.merged.markDuplicates.sorted"
     }
 
 #    TODO: Add Fingerprinting?

--- a/wdl/pipelines/ILMN/Alignment/SRFlowcell.wdl
+++ b/wdl/pipelines/ILMN/Alignment/SRFlowcell.wdl
@@ -393,6 +393,7 @@ workflow SRFlowcell {
         # Contaminated BAM file:
         # TODO: This will need to be fixed for optional finalization:
         File? contaminated_bam = t_005_DecontaminateSample.contaminated_bam
+        File? contaminated_bam_index = t_005_DecontaminateSample.contaminated_bam_index
 
         ##############################
         # Statistics:

--- a/wdl/pipelines/Z_One_Off_Analyses/BroadOnPremMalariaPipeline_1_Alignment_and_Variant_Calling.wdl
+++ b/wdl/pipelines/Z_One_Off_Analyses/BroadOnPremMalariaPipeline_1_Alignment_and_Variant_Calling.wdl
@@ -625,6 +625,11 @@ task HaplotypeCaller {
 
         ################################
 
+        # Must copy the input bam index to the same directory as the input bam.
+        # We have to do this because the GATK will look for the index in the same directory as the input bam
+        # and it may not be there due to us indexing it in a separate task.
+        mv ~{input_bai} $(dirname ~{input_bam})/
+
         java_memory_size_mb=$((tot_mem_mb-5120))
 
         java -Xmx${java_memory_size_mb}M -jar /usr/GenomeAnalysisTK.jar \

--- a/wdl/pipelines/Z_One_Off_Analyses/BroadOnPremMalariaPipeline_1_Alignment_and_Variant_Calling.wdl
+++ b/wdl/pipelines/Z_One_Off_Analyses/BroadOnPremMalariaPipeline_1_Alignment_and_Variant_Calling.wdl
@@ -511,7 +511,7 @@ task BQSR {
     Int compression_level = 2
 
     Int known_sites_size = ceil(size(known_sites, "GB")) + ceil(size(known_sites_indices, "GB"))
-    Int disk_size = 1 + known_sites_size + 4*ceil(size([input_bam, input_bai, reference_fasta, reference_fai, reference_dict], "GB"))
+    Int disk_size = 10 + known_sites_size + 20*ceil(size([input_bam, input_bai, reference_fasta, reference_fai, reference_dict], "GB"))
 
     # Task is assuming query-sorted input so that the Secondary and Supplementary reads get marked correctly
     # This works because the output of BWA is query-grouped and therefore, so is the output of MergeBamAlignment.

--- a/wdl/pipelines/Z_One_Off_Analyses/BroadOnPremMalariaPipeline_1_Alignment_and_Variant_Calling.wdl
+++ b/wdl/pipelines/Z_One_Off_Analyses/BroadOnPremMalariaPipeline_1_Alignment_and_Variant_Calling.wdl
@@ -24,8 +24,11 @@ workflow BroadOnPremMalariaPipeline_1_Alignment {
         File contaminant_ref_map_file
 
         File resource_vcf_7g8_gb4
+        File resource_vcf_7g8_gb4_index
         File resource_vcf_hb3_dd2
+        File resource_vcf_hb3_dd2_index
         File resource_vcf_3d7_hb3
+        File resource_vcf_3d7_hb3_index
     }
 
     # Sanity checks:
@@ -164,7 +167,14 @@ workflow BroadOnPremMalariaPipeline_1_Alignment {
             reference_fasta = ref_map["fasta"],
             reference_fai = ref_map["fai"],
             reference_dict = ref_map["dict"],
-            known_sites = [resource_vcf_7g8_gb4, resource_vcf_hb3_dd2, resource_vcf_3d7_hb3],
+            known_sites = [
+                          resource_vcf_7g8_gb4,
+                          resource_vcf_7g8_gb4_index,
+                          resource_vcf_hb3_dd2,
+                          resource_vcf_hb3_dd2_index,
+                          resource_vcf_3d7_hb3,
+                          resource_vcf_3d7_hb3_index
+            ],
             prefix = sample_name + ".aligned.sorted.marked_duplicates.reordered.indels_realigned.bqsr"
     }
 
@@ -537,7 +547,7 @@ task BQSR {
                 -R ~{reference_fasta} \
                 -I ~{input_bam} \
                 -BQSR ~{prefix}_recal_report.grp \
-                -o ~{prefix}.bqsr.bam
+                -o ~{prefix}.bam
     >>>
 
     output {

--- a/wdl/pipelines/Z_One_Off_Analyses/BroadOnPremMalariaPipeline_1_Alignment_and_Variant_Calling.wdl
+++ b/wdl/pipelines/Z_One_Off_Analyses/BroadOnPremMalariaPipeline_1_Alignment_and_Variant_Calling.wdl
@@ -134,7 +134,8 @@ workflow BroadOnPremMalariaPipeline_1_Alignment {
     call Utils.SortSam as t_010_ReorderSam {
         input:
             input_bam = t_009_MarkDuplicates.bam,
-            output_bam_basename = sample_name + ".aligned.sorted.marked_duplicates.reordered"
+            output_bam_basename = sample_name + ".aligned.sorted.marked_duplicates.reordered",
+            compression_level = 2
     }
 
     # 5 - Realign indels:

--- a/wdl/pipelines/Z_One_Off_Analyses/BroadOnPremMalariaPipeline_1_Alignment_and_Variant_Calling.wdl
+++ b/wdl/pipelines/Z_One_Off_Analyses/BroadOnPremMalariaPipeline_1_Alignment_and_Variant_Calling.wdl
@@ -72,7 +72,7 @@ workflow BroadOnPremMalariaPipeline_1_Alignment {
             fq_end2 = fq_e2,
             human_reference_fasta = contaminant_ref_map["fasta"],
             human_reference_fai = contaminant_ref_map["fai"],
-            human_reference_1_bt2 = contaminant_ref_map["1_bt2"]
+            human_reference_1_bt2 = contaminant_ref_map["1.bt2"]
     }
 
     # 2 - Align to Plasmodium reference:

--- a/wdl/pipelines/Z_One_Off_Analyses/BroadOnPremMalariaPipeline_1_Alignment_and_Variant_Calling.wdl
+++ b/wdl/pipelines/Z_One_Off_Analyses/BroadOnPremMalariaPipeline_1_Alignment_and_Variant_Calling.wdl
@@ -80,8 +80,8 @@ workflow BroadOnPremMalariaPipeline_1_Alignment {
     # 2a - Align reads to reference with BWA-MEM2:
     call SRUTIL.BwaMem2 as t_006_AlignReads {
         input:
-            fq_end1 = fq_e1,
-            fq_end2 = fq_e2,
+            fq_end1 = t_005_FilterOutHumanReads.fq1,
+            fq_end2 = t_005_FilterOutHumanReads.fq2,
             ref_fasta = ref_map["fasta"],
             ref_fasta_index = ref_map["fai"],
             ref_dict = ref_map["dict"],

--- a/wdl/pipelines/Z_One_Off_Analyses/BroadOnPremMalariaPipeline_1_Alignment_and_Variant_Calling.wdl
+++ b/wdl/pipelines/Z_One_Off_Analyses/BroadOnPremMalariaPipeline_1_Alignment_and_Variant_Calling.wdl
@@ -108,12 +108,10 @@ workflow BroadOnPremMalariaPipeline_1_Alignment {
     }
 
     # 2b - Sort Bam:
-    # TODO: Picard Version is not the same!  Does it matter?
     call Utils.SortSam as t_008_SortAlignedBam {
         input:
             input_bam = t_006_AlignReads.bam,
-            output_bam_basename = sample_name + ".aligned.sorted",
-            compression_level = 2
+            prefix = sample_name + ".aligned.sorted"
     }
 
     # 3 - Mark duplicates:
@@ -138,8 +136,7 @@ workflow BroadOnPremMalariaPipeline_1_Alignment {
     call Utils.SortSam as t_010_ReorderSam {
         input:
             input_bam = t_009_MarkDuplicates.bam,
-            output_bam_basename = sample_name + ".aligned.sorted.marked_duplicates.reordered",
-            compression_level = 2
+            prefix = sample_name + ".aligned.sorted.marked_duplicates.reordered"
     }
 
     # 5 - Realign indels:

--- a/wdl/pipelines/Z_One_Off_Analyses/BroadOnPremMalariaPipeline_1_Alignment_and_Variant_Calling.wdl
+++ b/wdl/pipelines/Z_One_Off_Analyses/BroadOnPremMalariaPipeline_1_Alignment_and_Variant_Calling.wdl
@@ -169,10 +169,12 @@ workflow BroadOnPremMalariaPipeline_1_Alignment {
             reference_dict = ref_map["dict"],
             known_sites = [
                           resource_vcf_7g8_gb4,
-                          resource_vcf_7g8_gb4_index,
                           resource_vcf_hb3_dd2,
+                          resource_vcf_3d7_hb3
+                ],
+            known_sites_indices = [
+                          resource_vcf_7g8_gb4_index,
                           resource_vcf_hb3_dd2_index,
-                          resource_vcf_3d7_hb3,
                           resource_vcf_3d7_hb3_index
             ],
             prefix = sample_name + ".aligned.sorted.marked_duplicates.reordered.indels_realigned.bqsr"
@@ -501,6 +503,7 @@ task BQSR {
         File reference_dict
 
         Array[File] known_sites
+        Array[File] known_sites_indices
 
         RuntimeAttr? runtime_attr_override
     }

--- a/wdl/pipelines/Z_One_Off_Analyses/BroadOnPremMalariaPipeline_1_Alignment_and_Variant_Calling.wdl
+++ b/wdl/pipelines/Z_One_Off_Analyses/BroadOnPremMalariaPipeline_1_Alignment_and_Variant_Calling.wdl
@@ -1,0 +1,639 @@
+version 1.0
+
+import "../../tasks/Z_One_Off_Analyses/BroadOnPremMalariaPipelineTasks.wdl" as BroadOnPremMalariaPipelineTasks
+import "../../tasks/Utility/SRUtils.wdl" as SRUTIL
+import "../../tasks/Utility/Utils.wdl" as Utils
+import "../../structs/Structs.wdl"
+
+
+workflow BroadOnPremMalariaPipeline_1_Alignment {
+    meta {
+        desciption: "Recreation of the first and second steps of the Broad OnPrem Malaria Pipeline.  Aligns reads and filters out human contamination, then calls variants and creates both a GVCF file and a recalibrated variants file."
+    }
+    input {
+        String sample_name
+
+        File? bam
+        File? bai
+
+        File? fq_end1
+        File? fq_end2
+
+        File ref_map_file
+        String contaminant_ref_name
+        File contaminant_ref_map_file
+
+        File resource_vcf_7g8_gb4
+        File resource_vcf_hb3_dd2
+        File resource_vcf_3d7_hb3
+    }
+
+    # Sanity checks:
+    if ((!defined(bam) && !defined(bai)) && (!defined(fq_end1) && !defined(fq_end2))) {
+        call Error as UserErrorMissingInputFiles {
+            input:
+                message = "Either 'bam' and 'bai' or 'fq_end1' and 'fq_end2' must be provided."
+        }
+    }
+
+    # Get ref info:
+    Map[String, String] ref_map = read_map(ref_map_file)
+    Map[String, String] contaminant_ref_map = read_map(contaminant_ref_map_file)
+
+    # Call our timestamp so we can store outputs without clobbering previous runs:
+    call Utils.GetCurrentTimestampString as t_001_WdlExecutionStartTimestamp { input: }
+
+    if (defined(bam)) {
+        # Convert the given bam to a uBAM (needed for previous aligned data):
+        call SRUTIL.RevertSam as t_002_RevertSam {
+            input:
+                input_bam = select_first([bam]),
+                prefix = sample_name + ".revertSam"
+        }
+
+        # Convert input SAM/BAM to FASTQ:
+        call SRUTIL.BamToFq as t_003_Bam2Fastq {
+            input:
+                bam = t_002_RevertSam.bam,
+                prefix = sample_name
+        }
+
+        call Utils.GetRawReadGroup as t_004_GetRawReadGroup { input: gcs_bam_path = select_first([bam]) }
+    }
+
+    File fq_e1 = select_first([fq_end1, t_003_Bam2Fastq.fq_end1])
+    File fq_e2 = select_first([fq_end2, t_003_Bam2Fastq.fq_end2])
+
+    # 1 - Filter out human reads:
+    call FilterOutHumanReads as t_005_FilterOutHumanReads {
+        input:
+            prefix = sample_name,
+            fq_end1 = fq_e1,
+            fq_end2 = fq_e2,
+            human_reference_fasta = ref_map["human_reference_fasta"],
+            human_reference_fai = ref_map["human_reference_fai"]
+    }
+
+    # 2 - Align to Plasmodium reference:
+    String RG = "@RG\tID:FLOWCELL_~{sample_name}\tSM:~{sample_name}\tPL:ILLUMINA\tLB:LIB_~{sample_name}"
+
+    # 2a - Align reads to reference with BWA-MEM2:
+    call SRUTIL.BwaMem2 as t_006_AlignReads {
+        input:
+            fq_end1 = fq_e1,
+            fq_end2 = fq_e2,
+            ref_fasta = ref_map["fasta"],
+            ref_fasta_index = ref_map["fai"],
+            ref_dict = ref_map["dict"],
+            ref_0123 = ref_map["0123"],
+            ref_amb = ref_map["amb"],
+            ref_ann = ref_map["ann"],
+            ref_bwt = ref_map["bwt"],
+            ref_pac = ref_map["pac"],
+            mark_short_splits_as_secondary = true,
+            read_group = RG,
+            prefix = sample_name + ".aligned"
+    }
+
+    # 2b - Sort Bam:
+    # TODO: Picard Version is not the same!  Does it matter?
+    call Utils.SortSam as t_008_SortAlignedBam {
+        input:
+            input_bam = t_006_AlignReads.bam,
+            output_bam_basename = sample_name + ".aligned.sorted",
+            compression_level = 2
+    }
+
+    # 3 - Mark duplicates:
+    # TODO: Picard Version is not the same!  Does it matter?
+    call SRUTIL.MarkDuplicates as t_009_MarkDuplicates {
+        input:
+            input_bam = t_008_SortAlignedBam.output_bam,
+            prefix = sample_name + ".aligned.sorted.marked_duplicates"
+    }
+
+    # 4 - Reorder bam:
+    call ReorderSam as t_010_ReorderSam {
+        input:
+            input_bam = t_009_MarkDuplicates.bam,
+            reference_fasta = ref_map["fasta"],
+            reference_fai = ref_map["fai"],
+            reference_dict = ref_map["dict"],
+            prefix = sample_name + ".aligned.sorted.marked_duplicates.reordered"
+    }
+
+    # 5 - Realign indels:
+    call RealignIndels as t_011_RealignIndels {
+        input:
+            input_bam = t_010_ReorderSam.bam,
+            input_bai = t_010_ReorderSam.bai,
+            reference_fasta = ref_map["fasta"],
+            reference_fai = ref_map["fai"],
+            reference_dict = ref_map["dict"],
+            prefix = sample_name + ".aligned.sorted.marked_duplicates.reordered.indels_realigned"
+    }
+
+    # 6 - BQSR:
+    call BQSR as t_012_BQSR {
+        input:
+            input_bam = t_011_RealignIndels.indel_realigned_bam,
+            input_bai = t_011_RealignIndels.indel_realigned_bai,
+            reference_fasta = ref_map["fasta"],
+            reference_fai = ref_map["fai"],
+            reference_dict = ref_map["dict"],
+            known_sites = [resource_vcf_7g8_gb4, resource_vcf_hb3_dd2, resource_vcf_3d7_hb3],
+            prefix = sample_name + ".aligned.sorted.marked_duplicates.reordered.indels_realigned.bqsr"
+    }
+
+    # 7 - call variants with haplotypecaller:
+    # both VCF and GVCF mode:
+    call HaplotypeCaller as t_013_HaplotypeCaller {
+        input:
+            input_bam = t_012_BQSR.bqsr_bam,
+            input_bai = t_012_BQSR.bqsr_bai,
+            reference_fasta = ref_map["fasta"],
+            reference_fai = ref_map["fai"],
+            reference_dict = ref_map["dict"],
+            prefix = sample_name + ".raw"
+    }
+    call HaplotypeCaller as t_014_HaplotypeCallerGvcfMode {
+        input:
+            input_bam = t_012_BQSR.bqsr_bam,
+            input_bai = t_012_BQSR.bqsr_bai,
+            reference_fasta = ref_map["fasta"],
+            reference_fai = ref_map["fai"],
+            reference_dict = ref_map["dict"],
+            prefix = sample_name,
+            gvcf_mode = true
+    }
+
+    # 8 - Recalibrate variants:
+    call BroadOnPremMalariaPipelineTasks.VariantRecalibrator as t_015_VariantRecalibrator {
+        input:
+            input_vcf = t_013_HaplotypeCaller.vcf,
+            reference_fasta = ref_map["fasta"],
+            reference_fai = ref_map["fai"],
+            reference_dict = ref_map["dict"],
+            resource_vcf_7g8_gb4 = resource_vcf_7g8_gb4,
+            resource_vcf_hb3_dd2 = resource_vcf_hb3_dd2,
+            resource_vcf_3d7_hb3 = resource_vcf_3d7_hb3,
+            prefix = sample_name
+    }
+
+    # 9 - sort, compress, and index final outputs:
+    call BroadOnPremMalariaPipelineTasks.SortCompressIndexVcf as t_016_SortCompressIndexRawVCF {
+        input:
+            input_vcf = t_013_HaplotypeCaller.vcf
+    }
+
+    call BroadOnPremMalariaPipelineTasks.SortCompressIndexVcf as t_017_SortCompressIndexVCF {
+        input:
+            input_vcf = t_015_VariantRecalibrator.vcf
+    }
+
+    # 9 - sort, compress, and index final outputs:
+    call BroadOnPremMalariaPipelineTasks.SortCompressIndexVcf as t_018_SortCompressIndexGVCF {
+        input:
+            input_vcf = t_014_HaplotypeCallerGvcfMode.vcf
+    }
+
+    output {
+        File raw_vcf = t_016_SortCompressIndexRawVCF.vcf
+        File raw_vcf_index = t_016_SortCompressIndexRawVCF.vcf_index
+        File recalibrated_vcf = t_017_SortCompressIndexVCF.vcf
+        File recalibrated_vcf_index = t_017_SortCompressIndexVCF.vcf_index
+        File gvcf = t_018_SortCompressIndexGVCF.vcf
+        File gvcf_index = t_018_SortCompressIndexGVCF.vcf_index
+    }
+}
+
+task FilterOutHumanReads {
+
+    meta {
+        description: ""
+    }
+
+    parameter_meta {
+        prefix: "Prefix for output files."
+
+        fq_end1: "FASTQ file containing end 1 of reads."
+        fq_end2: "FASTQ file containing end 2 of reads."
+
+        human_reference_fasta: "Reference FASTA file for human genome."
+        human_reference_fai: "Reference FASTA index file for human genome."
+
+        runtime_attr_override: "Optional override for runtime attributes."
+    }
+
+    input {
+        String prefix
+
+        File fq_end1
+        File fq_end2
+
+        File human_reference_fasta
+        File human_reference_fai
+
+        RuntimeAttr? runtime_attr_override
+    }
+
+    Int disk_size = 10 + 10 * ceil(size([fq_end1, fq_end2, human_reference_fasta, human_reference_fai], "GB"))
+
+    command <<<
+        set -euxo pipefail
+
+        # Make sure we use all our proocesors:
+        np=$(cat /proc/cpuinfo | grep ^processor | tail -n1 | awk '{print $NF+1}')
+        if [[ ${np} -gt 2 ]] ; then
+            let np=${np}-1
+        fi
+
+        echo "Aligning to human genome:"
+        bowtie2 -x ~{human_reference_fasta} \
+            --threads ${np} \
+            -1 ~{fq_end1} \
+            -2 ~{fq_end2} | \
+        samtools view -@$((np-1)) -bS - > ~{prefix}.mapAndUnmapped.human.bam
+
+        echo "Filtering out human reads:"
+        samtools view -@$((np-1)) -b -f 12 -F 256 ~{prefix}.mapAndUnmapped.human.bam > ~{prefix}.unmapped.bam
+
+        echo "Sorting unmapped reads:"
+        samtools sort -@$((np-1)) -n ~{prefix}.unmapped.bam -o ~{prefix}.unmapped.sorted.bam
+
+        echo "Converting back to FASTQ:"
+        bedtools bamtofastq -i ~{prefix}.unmapped.sorted.bam \
+            -fq ~{prefix}.hostRemoved.1.fq \
+            -fq2 ~{prefix}.hostRemoved.2.fq
+    >>>
+
+    output {
+        File fq1 = "~{prefix}.hostRemoved.1.fq"
+        File fq2 = "~{prefix}.hostRemoved.2.fq"
+    }
+
+    #########################
+    RuntimeAttr default_attr = object {
+        cpu_cores:          4,
+        mem_gb:             32,
+        disk_gb:            disk_size,
+        boot_disk_gb:       10,
+        preemptible_tries:  2,
+        max_retries:        1,
+        docker:             "us.gcr.io/broad-dsp-lrma/sr-alternate-tools:0.0.1"
+    }
+    RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
+    runtime {
+        cpu:                    select_first([runtime_attr.cpu_cores,         default_attr.cpu_cores])
+        memory:                 select_first([runtime_attr.mem_gb,            default_attr.mem_gb]) + " GiB"
+        disks: "local-disk " +  select_first([runtime_attr.disk_gb,           default_attr.disk_gb]) + " HDD"
+        bootDiskSizeGb:         select_first([runtime_attr.boot_disk_gb,      default_attr.boot_disk_gb])
+        preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
+        maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])
+        docker:                 select_first([runtime_attr.docker,            default_attr.docker])
+    }
+}
+
+task ReorderSam {
+    input {
+        File input_bam
+
+        String prefix
+
+        File reference_fasta
+        File reference_fai
+        File reference_dict
+
+        RuntimeAttr? runtime_attr_override
+    }
+
+    Int compression_level = 2
+
+    Int disk_size = 1 + 4*ceil(size([input_bam, reference_fasta], "GB"))
+
+    # Task is assuming query-sorted input so that the Secondary and Supplementary reads get marked correctly
+    # This works because the output of BWA is query-grouped and therefore, so is the output of MergeBamAlignment.
+    # While query-grouped isn't actually query-sorted, it's good enough for MarkDuplicates with ASSUME_SORT_ORDER="queryname"
+
+    command <<<
+        set -euxo pipefail
+
+        tot_mem_mb=$(free -m | grep '^Mem' | awk '{print $2}')
+        java_memory_size_mb=$((tot_mem_mb-5120))
+
+        java -Dsamjdk.compression_level=~{compression_level} -Xms${java_memory_size_mb}m -jar /usr/picard/picard.jar \
+            ReorderSam \
+                INPUT=~{input_bam} \
+                OUTPUT=~{prefix}.bam \
+                REFERENCE_SEQUENCE=~{reference_fasta} \
+                SEQUENCE_DICTIONARY=~{reference_dict} \
+
+        samtools index -@${np} ~{prefix}.bam
+    >>>
+
+    output {
+        File bam = "~{prefix}.bam"
+        File bai = "~{prefix}.bai"
+    }
+
+    #########################
+    RuntimeAttr default_attr = object {
+        cpu_cores:          2,
+        mem_gb:             16,
+        disk_gb:            disk_size,
+        boot_disk_gb:       10,
+        preemptible_tries:  1,
+        max_retries:        1,
+        docker:             "us.gcr.io/broad-gotc-prod/picard-cloud:2.26.10"
+    }
+    RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
+    runtime {
+        cpu:                    select_first([runtime_attr.cpu_cores,         default_attr.cpu_cores])
+        memory:                 select_first([runtime_attr.mem_gb,            default_attr.mem_gb]) + " GiB"
+        disks: "local-disk " +  select_first([runtime_attr.disk_gb,           default_attr.disk_gb]) + " HDD"
+        bootDiskSizeGb:         select_first([runtime_attr.boot_disk_gb,      default_attr.boot_disk_gb])
+        preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
+        maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])
+        docker:                 select_first([runtime_attr.docker,            default_attr.docker])
+    }
+}
+
+task RealignIndels {
+    input {
+        String prefix
+
+        File input_bam
+        File input_bai
+
+        File reference_fasta
+        File reference_fai
+        File reference_dict
+
+        RuntimeAttr? runtime_attr_override
+    }
+
+    Int compression_level = 2
+
+    Int disk_size = 1 + 4*ceil(size([input_bam, reference_fasta], "GB"))
+
+    # Task is assuming query-sorted input so that the Secondary and Supplementary reads get marked correctly
+    # This works because the output of BWA is query-grouped and therefore, so is the output of MergeBamAlignment.
+    # While query-grouped isn't actually query-sorted, it's good enough for MarkDuplicates with ASSUME_SORT_ORDER="queryname"
+
+    command <<<
+        ################################
+        # Standard Preamble
+
+        set -euxo pipefail
+
+        # Make sure we use all our proocesors:
+        np=$(cat /proc/cpuinfo | grep ^processor | tail -n1 | awk '{print $NF+1}')
+        if [[ ${np} -gt 2 ]] ; then
+            let np=${np}-1
+        fi
+
+        tot_mem_mb=$(free -m | grep '^Mem' | awk '{print $2}')
+
+        ################################
+
+        java_memory_size_mb=$((tot_mem_mb-5120))
+
+        # Create regions for indel realignment:
+        java -Xmx${java_memory_size_mb}M -jar /usr/GenomeAnalysisTK.jar \
+            -T RealignerTargetCreator \
+                -nct 1 \
+                -nt ${np} \
+                -R ~{reference_fasta} \
+                -I ~{input_bam} \
+                -o ~{prefix}.interval_list
+
+        java -Xmx${java_memory_size_mb}M -jar /usr/GenomeAnalysisTK.jar \
+            -T IndelRealigner \
+                -nct 1 \
+                -nt 1 \
+                -R ~{reference_fasta} \
+                -I ~{input_bam} \
+                -targetIntervals ~{prefix}.interval_list \
+                -o ~{prefix}.bam
+
+        samtools index -@${np} ~{prefix}.bam
+    >>>
+
+    output {
+        File indel_realigned_bam = "~{prefix}.bam"
+        File indel_realigned_bai = "~{prefix}.bam.bai"
+    }
+
+    #########################
+    RuntimeAttr default_attr = object {
+        cpu_cores:          8,
+        mem_gb:             32,
+        disk_gb:            disk_size,
+        boot_disk_gb:       10,
+        preemptible_tries:  1,
+        max_retries:        1,
+        docker:             "broadinstitute/gatk3:3.5-0"
+    }
+    RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
+    runtime {
+        cpu:                    select_first([runtime_attr.cpu_cores,         default_attr.cpu_cores])
+        memory:                 select_first([runtime_attr.mem_gb,            default_attr.mem_gb]) + " GiB"
+        disks: "local-disk " +  select_first([runtime_attr.disk_gb,           default_attr.disk_gb]) + " HDD"
+        bootDiskSizeGb:         select_first([runtime_attr.boot_disk_gb,      default_attr.boot_disk_gb])
+        preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
+        maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])
+        docker:                 select_first([runtime_attr.docker,            default_attr.docker])
+    }
+}
+
+
+task BQSR {
+    input {
+        String prefix
+
+        File input_bam
+        File input_bai
+
+        File reference_fasta
+        File reference_fai
+        File reference_dict
+
+        Array[File] known_sites
+
+        RuntimeAttr? runtime_attr_override
+    }
+
+    Int compression_level = 2
+
+    Int disk_size = 1 + 4*ceil(size([input_bam, reference_fasta], "GB"))
+
+    # Task is assuming query-sorted input so that the Secondary and Supplementary reads get marked correctly
+    # This works because the output of BWA is query-grouped and therefore, so is the output of MergeBamAlignment.
+    # While query-grouped isn't actually query-sorted, it's good enough for MarkDuplicates with ASSUME_SORT_ORDER="queryname"
+
+    command <<<
+        ################################
+        # Standard Preamble
+
+        set -euxo pipefail
+
+        # Make sure we use all our proocesors:
+        np=$(cat /proc/cpuinfo | grep ^processor | tail -n1 | awk '{print $NF+1}')
+        if [[ ${np} -gt 2 ]] ; then
+            let np=${np}-1
+        fi
+
+        tot_mem_mb=$(free -m | grep '^Mem' | awk '{print $2}')
+
+        ################################
+
+        java_memory_size_mb=$((tot_mem_mb-5120))
+
+        java -Xmx${java_memory_size_mb}M -jar /usr/GenomeAnalysisTK.jar \
+            -T BaseRecalibrator \
+                -nct 8 \
+                -nt 1 \
+                -R ~{reference_fasta} \
+                -I ~{input_bam} \
+                -knownSites ~{sep=" -knownSites " known_sites} \
+                -o ~{prefix}_recal_report.grp
+
+        java -Xmx${java_memory_size_mb}M -jar /usr/GenomeAnalysisTK.jar \
+            -T PrintReads \
+                -nct 8 \
+                -nt 1 \
+                -R ~{reference_fasta} \
+                -I ~{input_bam} \
+                -BQSR ~{prefix}_recal_report.grp \
+                -o ~{prefix}.bqsr.bam
+
+        samtools index -@${np} ~{prefix}.bqsr.bam
+    >>>
+
+    output {
+        File bqsr_bam = "~{prefix}.bqsr.bam"
+        File bqsr_bai = "~{prefix}.bqsr.bam.bai"
+    }
+
+    #########################
+    RuntimeAttr default_attr = object {
+        cpu_cores:          8,
+        mem_gb:             32,
+        disk_gb:            disk_size,
+        boot_disk_gb:       10,
+        preemptible_tries:  1,
+        max_retries:        1,
+        docker:             "broadinstitute/gatk3:3.5-0"
+    }
+    RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
+    runtime {
+        cpu:                    select_first([runtime_attr.cpu_cores,         default_attr.cpu_cores])
+        memory:                 select_first([runtime_attr.mem_gb,            default_attr.mem_gb]) + " GiB"
+        disks: "local-disk " +  select_first([runtime_attr.disk_gb,           default_attr.disk_gb]) + " HDD"
+        bootDiskSizeGb:         select_first([runtime_attr.boot_disk_gb,      default_attr.boot_disk_gb])
+        preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
+        maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])
+        docker:                 select_first([runtime_attr.docker,            default_attr.docker])
+    }
+}
+
+
+task HaplotypeCaller {
+    input {
+        String prefix
+
+        File input_bam
+        File input_bai
+
+        File reference_fasta
+        File reference_fai
+        File reference_dict
+
+        Boolean gvcf_mode = false
+
+        RuntimeAttr? runtime_attr_override
+    }
+
+    Int compression_level = 2
+
+    Int disk_size = 1 + 4*ceil(size([input_bam, reference_fasta], "GB"))
+
+    String gvcf_arg = if (gvcf_mode) then "-ERC GVCF" else ""
+    String out_suffix = if (gvcf_mode) then ".g.vcf" else ".vcf"
+
+    command <<<
+        ################################
+        # Standard Preamble
+
+        set -euxo pipefail
+
+        # Make sure we use all our proocesors:
+        np=$(cat /proc/cpuinfo | grep ^processor | tail -n1 | awk '{print $NF+1}')
+        if [[ ${np} -gt 2 ]] ; then
+            let np=${np}-1
+        fi
+
+        tot_mem_mb=$(free -m | grep '^Mem' | awk '{print $2}')
+
+        ################################
+
+        java_memory_size_mb=$((tot_mem_mb-5120))
+
+        java -Xmx${java_memory_size_mb}M -jar /usr/GenomeAnalysisTK.jar \
+            -T HaplotypeCaller \
+                -nt 1 \
+                -R ~{reference_fasta} \
+                -I ~{input_bam} \
+                ~{gvcf_arg} \
+                -ploidy 2 \
+                --interval_padding 100 \
+                -o ~{prefix}.~{out_suffix} \
+                -variant_index_type LINEAR \
+                -variant_index_parameter 128000
+    >>>
+
+    output {
+        File vcf = "~{prefix}.~{out_suffix}"
+    }
+
+    #########################
+    RuntimeAttr default_attr = object {
+        cpu_cores:          8,
+        mem_gb:             32,
+        disk_gb:            disk_size,
+        boot_disk_gb:       10,
+        preemptible_tries:  1,
+        max_retries:        1,
+        docker:             "broadinstitute/gatk3:3.5-0"
+    }
+    RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
+    runtime {
+        cpu:                    select_first([runtime_attr.cpu_cores,         default_attr.cpu_cores])
+        memory:                 select_first([runtime_attr.mem_gb,            default_attr.mem_gb]) + " GiB"
+        disks: "local-disk " +  select_first([runtime_attr.disk_gb,           default_attr.disk_gb]) + " HDD"
+        bootDiskSizeGb:         select_first([runtime_attr.boot_disk_gb,      default_attr.boot_disk_gb])
+        preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
+        maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])
+        docker:                 select_first([runtime_attr.docker,            default_attr.docker])
+    }
+}
+
+task Error {
+
+    input {
+        String message
+    }
+    command {
+        set -euxo pipefail
+        echo ~{message}
+        exit 1
+    }
+    runtime {
+        docker: "ubuntu:22.04"
+        memory: "512 MB"
+        disks: "local-disk 10 HDD"
+        bootDiskSizeGb: "10"
+        preemptible: 1
+        cpu: 1
+    }
+}

--- a/wdl/pipelines/Z_One_Off_Analyses/BroadOnPremMalariaPipeline_1_Alignment_and_Variant_Calling.wdl
+++ b/wdl/pipelines/Z_One_Off_Analyses/BroadOnPremMalariaPipeline_1_Alignment_and_Variant_Calling.wdl
@@ -70,8 +70,8 @@ workflow BroadOnPremMalariaPipeline_1_Alignment {
             prefix = sample_name,
             fq_end1 = fq_e1,
             fq_end2 = fq_e2,
-            human_reference_fasta = ref_map["human_reference_fasta"],
-            human_reference_fai = ref_map["human_reference_fai"]
+            human_reference_fasta = contaminant_ref_map["fasta"],
+            human_reference_fai = contaminant_ref_map["fai"]
     }
 
     # 2 - Align to Plasmodium reference:

--- a/wdl/pipelines/Z_One_Off_Analyses/BroadOnPremMalariaPipeline_1_Alignment_and_Variant_Calling.wdl
+++ b/wdl/pipelines/Z_One_Off_Analyses/BroadOnPremMalariaPipeline_1_Alignment_and_Variant_Calling.wdl
@@ -120,21 +120,28 @@ workflow BroadOnPremMalariaPipeline_1_Alignment {
             prefix = sample_name + ".aligned.sorted.marked_duplicates"
     }
 
-    # 4 - Reorder bam:
-    call ReorderSam as t_010_ReorderSam {
+#    # 4 - Reorder bam is BROKEN.
+#    # USING SORT SAM.
+#    call ReorderSam as t_010_ReorderSam {
+#        input:
+#            input_bam = t_009_MarkDuplicates.bam,
+#            reference_fasta = ref_map["fasta"],
+#            reference_fai = ref_map["fai"],
+#            reference_dict = ref_map["dict"],
+#            prefix = sample_name + ".aligned.sorted.marked_duplicates.reordered"
+#    }
+
+    call Utils.SortSam as t_010_ReorderSam {
         input:
             input_bam = t_009_MarkDuplicates.bam,
-            reference_fasta = ref_map["fasta"],
-            reference_fai = ref_map["fai"],
-            reference_dict = ref_map["dict"],
-            prefix = sample_name + ".aligned.sorted.marked_duplicates.reordered"
+            output_bam_basename = sample_name + ".aligned.sorted.marked_duplicates.reordered"
     }
 
     # 5 - Realign indels:
     call RealignIndels as t_011_RealignIndels {
         input:
-            input_bam = t_010_ReorderSam.bam,
-            input_bai = t_010_ReorderSam.bai,
+            input_bam = t_010_ReorderSam.output_bam,
+            input_bai = t_010_ReorderSam.output_bam_index,
             reference_fasta = ref_map["fasta"],
             reference_fai = ref_map["fai"],
             reference_dict = ref_map["dict"],

--- a/wdl/pipelines/Z_One_Off_Analyses/BroadOnPremMalariaPipeline_1_Alignment_and_Variant_Calling.wdl
+++ b/wdl/pipelines/Z_One_Off_Analyses/BroadOnPremMalariaPipeline_1_Alignment_and_Variant_Calling.wdl
@@ -536,7 +536,7 @@ task BQSR {
         # Must copy the input bam index to the same directory as the input bam.
         # We have to do this because the GATK will look for the index in the same directory as the input bam
         # and it may not be there due to us indexing it in a separate task.
-        cp ~{input_bai} $(dirname ~{input_bam})/
+        mv ~{input_bai} $(dirname ~{input_bam})/
 
         java_memory_size_mb=$((tot_mem_mb-5120))
 
@@ -560,7 +560,7 @@ task BQSR {
     >>>
 
     output {
-        File bqsr_bam = "~{prefix}.bqsr.bam"
+        File bqsr_bam = "~{prefix}.bam"
     }
 
     #########################

--- a/wdl/pipelines/Z_One_Off_Analyses/BroadOnPremMalariaPipeline_1_Alignment_and_Variant_Calling.wdl
+++ b/wdl/pipelines/Z_One_Off_Analyses/BroadOnPremMalariaPipeline_1_Alignment_and_Variant_Calling.wdl
@@ -71,7 +71,8 @@ workflow BroadOnPremMalariaPipeline_1_Alignment {
             fq_end1 = fq_e1,
             fq_end2 = fq_e2,
             human_reference_fasta = contaminant_ref_map["fasta"],
-            human_reference_fai = contaminant_ref_map["fai"]
+            human_reference_fai = contaminant_ref_map["fai"],
+            human_reference_1_bt2 = contaminant_ref_map["1_bt2"]
     }
 
     # 2 - Align to Plasmodium reference:
@@ -209,10 +210,6 @@ workflow BroadOnPremMalariaPipeline_1_Alignment {
 
 task FilterOutHumanReads {
 
-    meta {
-        description: ""
-    }
-
     parameter_meta {
         prefix: "Prefix for output files."
 
@@ -232,12 +229,13 @@ task FilterOutHumanReads {
         File fq_end2
 
         File human_reference_fasta
+        File human_reference_1_bt2
         File human_reference_fai
 
         RuntimeAttr? runtime_attr_override
     }
 
-    Int disk_size = 10 + 10 * ceil(size([fq_end1, fq_end2, human_reference_fasta, human_reference_fai], "GB"))
+    Int disk_size = 10 + 10 * ceil(size([fq_end1, fq_end2, human_reference_fasta, human_reference_fai, human_reference_1_bt2], "GB"))
 
     command <<<
         set -euxo pipefail
@@ -249,7 +247,7 @@ task FilterOutHumanReads {
         fi
 
         echo "Aligning to human genome:"
-        bowtie2 -x ~{human_reference_fasta} \
+        bowtie2 -x ~{human_reference_1_bt2} \
             --threads ${np} \
             -1 ~{fq_end1} \
             -2 ~{fq_end2} | \

--- a/wdl/pipelines/Z_One_Off_Analyses/BroadOnPremMalariaPipeline_1_Alignment_and_Variant_Calling.wdl
+++ b/wdl/pipelines/Z_One_Off_Analyses/BroadOnPremMalariaPipeline_1_Alignment_and_Variant_Calling.wdl
@@ -218,6 +218,9 @@ workflow BroadOnPremMalariaPipeline_1_Alignment {
             resource_vcf_7g8_gb4 = resource_vcf_7g8_gb4,
             resource_vcf_hb3_dd2 = resource_vcf_hb3_dd2,
             resource_vcf_3d7_hb3 = resource_vcf_3d7_hb3,
+            resource_vcf_3d7_hb3_index = resource_vcf_3d7_hb3_index,
+            resource_vcf_hb3_dd2_index = resource_vcf_hb3_dd2_index,
+            resource_vcf_7g8_gb4_index = resource_vcf_7g8_gb4_index,
             prefix = sample_name
     }
 

--- a/wdl/pipelines/Z_One_Off_Analyses/BroadOnPremMalariaPipeline_2_JointVariantCalling.wdl
+++ b/wdl/pipelines/Z_One_Off_Analyses/BroadOnPremMalariaPipeline_2_JointVariantCalling.wdl
@@ -1,0 +1,127 @@
+version 1.0
+
+import "../../tasks/Utility/Utils.wdl" as Utils
+import "../../structs/Structs.wdl"
+
+import "../../tasks/Z_One_Off_Analyses/BroadOnPremMalariaPipelineTasks.wdl" as BroadOnPremMalariaPipelineTasks
+
+workflow BroadOnPremMalariaPipeline_2_JointVariantCalling {
+    meta {
+        desciption: "Recreation of the second step of the Broad OnPrem Malaria Pipeline.  Joint calls and recalibrates/filters variants."
+    }
+    input {
+        String sample_name
+
+        Array[File] vcf_files
+        Array[File] vcf_index_files
+
+        File ref_map_file
+
+        File resource_vcf_7g8_gb4
+        File resource_vcf_hb3_dd2
+        File resource_vcf_3d7_hb3
+    }
+
+    # Get ref info:
+    Map[String, String] ref_map = read_map(ref_map_file)
+
+    call GenotypeGVCFs as t_001_GenotypeGVCFs {
+        input:
+            prefix = sample_name,
+            input_vcfs = vcf_files,
+            input_vcf_indices = vcf_index_files,
+            reference_fasta = ref_map["reference_fasta"],
+            reference_fai = ref_map["reference_fai"],
+            reference_dict = ref_map["reference_dict"]
+    }
+
+    call BroadOnPremMalariaPipelineTasks.VariantRecalibrator as t_002_VariantRecalibrator {
+        input:
+            prefix = sample_name,
+            input_vcf = t_001_GenotypeGVCFs.vcf,
+            reference_fasta = ref_map["reference_fasta"],
+            reference_fai = ref_map["reference_fai"],
+            reference_dict = ref_map["reference_dict"],
+            resource_vcf_7g8_gb4 = resource_vcf_7g8_gb4,
+            resource_vcf_hb3_dd2 = resource_vcf_hb3_dd2,
+            resource_vcf_3d7_hb3 = resource_vcf_3d7_hb3
+    }
+
+    # 9 - sort, compress, and index final outputs:
+    call BroadOnPremMalariaPipelineTasks.SortCompressIndexVcf as t_003_SortCompressIndexVcf {
+        input:
+            input_vcf = t_002_VariantRecalibrator.vcf,
+    }
+
+    output {
+        File joint_vcf = t_003_SortCompressIndexVcf.vcf
+        File joint_vcf_index = t_003_SortCompressIndexVcf.vcf_index
+    }
+}
+
+task GenotypeGVCFs {
+    input {
+        String prefix
+
+        Array[File] input_vcfs
+        Array[File] input_vcf_indices
+
+        File reference_fasta
+        File reference_fai
+        File reference_dict
+
+        RuntimeAttr? runtime_attr_override
+    }
+
+    Int disk_size = 1 + 10*ceil(size([input_vcfs, reference_fasta], "GB"))
+
+    command <<<
+        ################################
+        # Standard Preamble
+
+        set -euxo pipefail
+
+        # Make sure we use all our proocesors:
+        np=$(cat /proc/cpuinfo | grep ^processor | tail -n1 | awk '{print $NF+1}')
+        if [[ ${np} -gt 2 ]] ; then
+            let np=${np}-1
+        fi
+
+        tot_mem_mb=$(free -m | grep '^Mem' | awk '{print $2}')
+
+        ################################
+
+        java_memory_size_mb=$((tot_mem_mb-5120))
+
+        java -Xmx${java_memory_size_mb}M -jar /usr/GenomeAnalysisTK.jar \
+            -T GenotypeGVCFs \
+                -R ~{reference_fasta} \
+                -o ~{prefix}_CombinedGVCFs.vcf \
+                -V ~{sep=" -V " input_vcfs}
+    >>>
+
+    output {
+        File vcf = "~{prefix}_CombinedGVCFs.vcf"
+    }
+
+    #########################
+    RuntimeAttr default_attr = object {
+        cpu_cores:          2,
+        mem_gb:             16,
+        disk_gb:            disk_size,
+        boot_disk_gb:       10,
+        preemptible_tries:  1,
+        max_retries:        1,
+        docker:             "broadinstitute/gatk3:3.5-0"
+    }
+    RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
+    runtime {
+        cpu:                    select_first([runtime_attr.cpu_cores,         default_attr.cpu_cores])
+        memory:                 select_first([runtime_attr.mem_gb,            default_attr.mem_gb]) + " GiB"
+        disks: "local-disk " +  select_first([runtime_attr.disk_gb,           default_attr.disk_gb]) + " HDD"
+        bootDiskSizeGb:         select_first([runtime_attr.boot_disk_gb,      default_attr.boot_disk_gb])
+        preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
+        maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])
+        docker:                 select_first([runtime_attr.docker,            default_attr.docker])
+    }
+}

--- a/wdl/tasks/Preprocessing/RemoveSingleOrganismContamination.wdl
+++ b/wdl/tasks/Preprocessing/RemoveSingleOrganismContamination.wdl
@@ -137,7 +137,7 @@ workflow RemoveSingleOrganismContamination {
     call Utils.SortSam as t_011_SortContaminatedReads {
         input:
             input_bam = t_009_ExtractContaminatedReads.output_bam,
-            output_bam_basename = SM + ".contaminated_" + contaminant_ref_name + "_reads.sorted"
+            prefix = SM + ".contaminated_" + contaminant_ref_name + "_reads.sorted"
     }
 
     # Convert input SAM/BAM to FASTQ:

--- a/wdl/tasks/Preprocessing/RemoveSingleOrganismContamination.wdl
+++ b/wdl/tasks/Preprocessing/RemoveSingleOrganismContamination.wdl
@@ -88,30 +88,28 @@ workflow RemoveSingleOrganismContamination {
 
     File fq_e1 = select_first([fq_end1, t_005_Bam2Fastq.fq_end1])
     File fq_e2 = select_first([fq_end2, t_005_Bam2Fastq.fq_end2])
-
-    String RG = select_first([t_006_GetRawReadGroup.rg, "@RG\tID:" + SM + "_" + LB + "\tPL:" + platform + "\tLB:" + LB + "\tSM:" + SM])
-
+    
     # Align data to contaminant reference:
-    call SRUTIL.BwaMem2 as t_007_AlignReads {
+    call SRUTIL.Bowtie2 as t_007_AlignReads {
         input:
             fq_end1 = fq_e1,
             fq_end2 = fq_e2,
 
             ref_fasta = ref_map["fasta"],
             ref_fasta_index = ref_map["fai"],
-            ref_dict = ref_map["dict"],
-            ref_0123 = ref_map["0123"],
-            ref_amb = ref_map["amb"],
-            ref_ann = ref_map["ann"],
-            ref_bwt = ref_map["bwt"],
-            ref_pac = ref_map["pac"],
-
-            mark_short_splits_as_secondary = true,
-
-            read_group = RG,
+            ref_bowtie_indices = [
+                ref_map["1.bt2"],
+                ref_map["2.bt2"],
+                ref_map["3.bt2"],
+                ref_map["4.bt2"],
+                ref_map["rev.1.bt2"],
+                ref_map["rev.2.bt2"]
+            ],
             prefix = SM + ".contaminant_aligned." + contaminant_ref_name,
-
-            runtime_attr_override = object {mem_gb: 64}  # Need a lot of ram to use BWA-MEM2
+            rg_id = SM + "_" + LB,
+            rg_pl = platform,
+            rg_lb = LB,
+            rg_sm = SM
     }
 
     call ExtractReadsWithSamtools as t_008_ExtractDecontaminatedReads {

--- a/wdl/tasks/Preprocessing/RemoveSingleOrganismContamination.wdl
+++ b/wdl/tasks/Preprocessing/RemoveSingleOrganismContamination.wdl
@@ -165,13 +165,13 @@ workflow RemoveSingleOrganismContamination {
         String outdir = if DEBUG_MODE then sub(concrete_gcs_out_root_dir, "/$", "") + "/RemoveSingleOrganismContamination/~{dir_prefix}/" + t_001_WdlExecutionStartTimestamp.timestamp_string else sub(concrete_gcs_out_root_dir, "/$", "") + "/RemoveSingleOrganismContamination/~{dir_prefix}"
 
         call FF.FinalizeToFile as t_013_FinalizeContaminatedBam { input: outdir = outdir, file = t_011_SortContaminatedReads.output_bam, keyfile = keyfile }
-        call FF.FinalizeToFile as t_013_FinalizeContaminatedBamIndex { input: outdir = outdir, file = t_011_SortContaminatedReads.output_bam_index, keyfile = keyfile }
-        call FF.FinalizeToFile as t_014_FinalizeDecontaminatedFq1 { input: outdir = outdir, file = t_012_CreateFastqFromDecontaminatedReads.fq_end1, keyfile = keyfile }
-        call FF.FinalizeToFile as t_015_FinalizeDecontaminatedFq2 { input: outdir = outdir, file = t_012_CreateFastqFromDecontaminatedReads.fq_end2, keyfile = keyfile }
-        call FF.FinalizeToFile as t_016_FinalizeDecontaminatedUnpaired { input: outdir = outdir, file = t_012_CreateFastqFromDecontaminatedReads.fq_unpaired, keyfile = keyfile }
+        call FF.FinalizeToFile as t_014_FinalizeContaminatedBamIndex { input: outdir = outdir, file = t_011_SortContaminatedReads.output_bam_index, keyfile = keyfile }
+        call FF.FinalizeToFile as t_015_FinalizeDecontaminatedFq1 { input: outdir = outdir, file = t_012_CreateFastqFromDecontaminatedReads.fq_end1, keyfile = keyfile }
+        call FF.FinalizeToFile as t_016_FinalizeDecontaminatedFq2 { input: outdir = outdir, file = t_012_CreateFastqFromDecontaminatedReads.fq_end2, keyfile = keyfile }
+        call FF.FinalizeToFile as t_017_FinalizeDecontaminatedUnpaired { input: outdir = outdir, file = t_012_CreateFastqFromDecontaminatedReads.fq_unpaired, keyfile = keyfile }
     }
 
-
+ 
     ############################################
     #      ___        _               _
     #     / _ \ _   _| |_ _ __  _   _| |_
@@ -183,11 +183,11 @@ workflow RemoveSingleOrganismContamination {
 
     output {
         File contaminated_bam = select_first([t_013_FinalizeContaminatedBam.gcs_path, t_011_SortContaminatedReads.output_bam])
-        File contaminated_bam_index = select_first([t_013_FinalizeContaminatedBamIndex.gcs_path, t_011_SortContaminatedReads.output_bam_index])
+        File contaminated_bam_index = select_first([t_014_FinalizeContaminatedBamIndex.gcs_path, t_011_SortContaminatedReads.output_bam_index])
 
-        File decontaminated_fq1 = select_first([t_014_FinalizeDecontaminatedFq1.gcs_path, t_012_CreateFastqFromDecontaminatedReads.fq_end1])
-        File decontaminated_fq2 = select_first([t_015_FinalizeDecontaminatedFq2.gcs_path, t_012_CreateFastqFromDecontaminatedReads.fq_end2])
-        File decontaminated_unpaired = select_first([t_016_FinalizeDecontaminatedUnpaired.gcs_path, t_012_CreateFastqFromDecontaminatedReads.fq_unpaired])
+        File decontaminated_fq1 = select_first([t_015_FinalizeDecontaminatedFq1.gcs_path, t_012_CreateFastqFromDecontaminatedReads.fq_end1])
+        File decontaminated_fq2 = select_first([t_016_FinalizeDecontaminatedFq2.gcs_path, t_012_CreateFastqFromDecontaminatedReads.fq_end2])
+        File decontaminated_unpaired = select_first([t_017_FinalizeDecontaminatedUnpaired.gcs_path, t_012_CreateFastqFromDecontaminatedReads.fq_unpaired])
     }
 }
 

--- a/wdl/tasks/Utility/SRUtils.wdl
+++ b/wdl/tasks/Utility/SRUtils.wdl
@@ -305,10 +305,10 @@ task Bowtie2 {
             --threads ${np} \
             -1 ~{fq_end1} \
             -2 ~{fq_end2} \
-            ~{rgid_cmd} ~{rg_id_val} \
-            ~{rg_cmd} ~{rg_pl_val} \
-            ~{rg_cmd} ~{rg_lb_val} \
-            ~{rg_cmd} ~{rg_sm_val} | \ 
+            ~{rgid_cmd} "~{rg_id_val}" \
+            ~{rg_cmd} "~{rg_pl_val}" \
+            ~{rg_cmd} "~{rg_lb_val}" \
+            ~{rg_cmd} "~{rg_sm_val}" | \ 
         samtools view -bh --no-PG - > tmp.bam
 
         # Now sort the output:

--- a/wdl/tasks/Utility/SRUtils.wdl
+++ b/wdl/tasks/Utility/SRUtils.wdl
@@ -233,6 +233,106 @@ task BwaMem2 {
     }
 }
 
+task Bowtie2 {
+
+    parameter_meta {
+        prefix: "Prefix for output files."
+
+        fq_end1: "FASTQ file containing end 1 of reads."
+        fq_end2: "FASTQ file containing end 2 of reads."
+
+        ref_fasta: "Reference FASTA file for the genome of the organism to which to align reads."
+        ref_fasta_index: "Reference FASTA index file for the genome of the organism to which to align reads."
+        ref_bowtie_indices: "Bowtie2 indices for the given genome."
+
+        runtime_attr_override: "Optional override for runtime attributes."
+    }
+
+    input {
+        String prefix
+
+        File fq_end1
+        File fq_end2
+
+        File ref_fasta
+        File ref_fasta_index
+        Array[File] ref_bowtie_indices
+
+        Boolean skip_sort = false
+
+        String rg_id
+        String rg_pl
+        String rg_lb
+        String rg_sm
+
+        RuntimeAttr? runtime_attr_override
+    }
+
+    Int bowtie_index_size = ceil(size(ref_bowtie_indices, "GB"))
+    Int disk_size = 10 + 10 * (bowtie_index_size + ceil(size([fq_end1, fq_end2, ref_fasta, ref_fasta_index], "GB")))
+
+    String rgid_cmd = if defined(rg_id) then " --rg-id " else ""
+    String rg_cmd = if (defined(rg_pl) || defined(rg_lb) || defined(rg_sm)) then " --rg " else ""
+
+    String rg_id_val = if defined(rg_id) then select_first([rg_id]) else ""
+    String rg_pl_val = if defined(rg_pl) then "PL:" + select_first([rg_pl]) else ""
+    String rg_lb_val = if defined(rg_lb) then "LB:" + select_first([rg_lb]) else ""
+    String rg_sm_val = if defined(rg_sm) then "SM:" + select_first([rg_sm]) else ""
+
+    command <<<
+        set -euxo pipefail
+
+        # Make sure we use all our proocesors:
+        np=$(cat /proc/cpuinfo | grep ^processor | tail -n1 | awk '{print $NF+1}')
+        if [[ ${np} -gt 2 ]] ; then
+            np=$((np-1))
+        fi
+
+        echo "Aligning to genome:"
+        bowtie2 -x ~{ref_fasta} \
+            --threads ${np} \
+            -1 ~{fq_end1} \
+            -2 ~{fq_end2} | \
+            ~{rgid_cmd} ~{rg_id_val} \
+            ~{rg_cmd} ~{rg_pl_val} \
+            ~{rg_cmd} ~{rg_lb_val} \
+            ~{rg_cmd} ~{rg_sm_val} \
+        samtools view -@$((np-1)) -bh --no-PG - > tmp.bam
+
+        # Now sort the output:
+        if ~{skip_sort} ; then
+            mv tmp.bam ~{prefix}.bam
+        else
+            samtools sort -@$((np-1)) tmp.bam > ~{prefix}.bam
+        fi
+    >>>
+
+    output {
+        File bam = "~{prefix}.bam"
+    }
+
+    #########################
+    RuntimeAttr default_attr = object {
+        cpu_cores:          4,
+        mem_gb:             32,
+        disk_gb:            disk_size,
+        boot_disk_gb:       10,
+        preemptible_tries:  2,
+        max_retries:        1,
+        docker:             "us.gcr.io/broad-dsp-lrma/sr-alternate-tools:0.0.1"
+    }
+    RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
+    runtime {
+        cpu:                    select_first([runtime_attr.cpu_cores,         default_attr.cpu_cores])
+        memory:                 select_first([runtime_attr.mem_gb,            default_attr.mem_gb]) + " GiB"
+        disks: "local-disk " +  select_first([runtime_attr.disk_gb,           default_attr.disk_gb]) + " HDD"
+        bootDiskSizeGb:         select_first([runtime_attr.boot_disk_gb,      default_attr.boot_disk_gb])
+        preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
+        maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])
+        docker:                 select_first([runtime_attr.docker,            default_attr.docker])
+    }
+}
+
 task MergeBamAlignment {
     input {
         File aligned_bam

--- a/wdl/tasks/Utility/SRUtils.wdl
+++ b/wdl/tasks/Utility/SRUtils.wdl
@@ -304,7 +304,7 @@ task Bowtie2 {
         bowtie2 -x ${bowtie2_index_basename} \
             --threads ${np} \
             -1 ~{fq_end1} \
-            -2 ~{fq_end2} | \
+            -2 ~{fq_end2} \
             ~{rgid_cmd} ~{rg_id_val} \
             ~{rg_cmd} ~{rg_pl_val} \
             ~{rg_cmd} ~{rg_lb_val} \

--- a/wdl/tasks/Utility/SRUtils.wdl
+++ b/wdl/tasks/Utility/SRUtils.wdl
@@ -318,12 +318,12 @@ task Bowtie2 {
             samtools sort -@$((np-1)) tmp.bam > ~{prefix}.bam
         fi
 
-        samtools index ~{prefix}.bam
+        samtools index -@$((np-1)) ~{prefix}.bam
     >>>
 
     output {
         File bam = "~{prefix}.bam"
-        File bai = "~{prefix}.bai"
+        File bai = "~{prefix}.bam.bai"
     }
 
     #########################

--- a/wdl/tasks/Utility/SRUtils.wdl
+++ b/wdl/tasks/Utility/SRUtils.wdl
@@ -543,6 +543,7 @@ task BaseRecalibrator {
             -R ~{ref_fasta} \
             -I ~{input_bam} \
             --use-original-qualities \
+            --allow-missing-read-group true \
             -O ~{prefix}.txt \
             --known-sites ~{known_sites_vcf}
 
@@ -555,7 +556,9 @@ task BaseRecalibrator {
         boot_disk_gb:       10,
         preemptible_tries:  1,
         max_retries:        1,
-        docker:             "us.gcr.io/broad-gatk/gatk:4.5.0.0"
+        # docker:             "us.gcr.io/broad-gatk/gatk:4.5.0.0"
+        # Temporary snapshot build for testing the fix for BQSR issue https://github.com/broadinstitute/gatk/issues/6242
+        docker:             "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots/gatk-remote-builds:jonn-4dd794b3f4e4e4e6a86f309a5ea1b580bf774b7c-4.5.0.0-48-g4dd794b3f" 
     }
     RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
     runtime {

--- a/wdl/tasks/Utility/SRUtils.wdl
+++ b/wdl/tasks/Utility/SRUtils.wdl
@@ -260,10 +260,10 @@ task Bowtie2 {
 
         Boolean skip_sort = false
 
-        String rg_id
-        String rg_pl
-        String rg_lb
-        String rg_sm
+        String? rg_id
+        String? rg_pl
+        String? rg_lb
+        String? rg_sm
 
         RuntimeAttr? runtime_attr_override
     }

--- a/wdl/tasks/Utility/SRUtils.wdl
+++ b/wdl/tasks/Utility/SRUtils.wdl
@@ -543,7 +543,6 @@ task BaseRecalibrator {
             -R ~{ref_fasta} \
             -I ~{input_bam} \
             --use-original-qualities \
-            --allow-missing-read-group true \
             -O ~{prefix}.txt \
             --known-sites ~{known_sites_vcf}
 
@@ -556,9 +555,7 @@ task BaseRecalibrator {
         boot_disk_gb:       10,
         preemptible_tries:  1,
         max_retries:        1,
-        # docker:             "us.gcr.io/broad-gatk/gatk:4.5.0.0"
-        # Temporary snapshot build for testing the fix for BQSR issue https://github.com/broadinstitute/gatk/issues/6242
-        docker:             "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots/gatk-remote-builds:jonn-4dd794b3f4e4e4e6a86f309a5ea1b580bf774b7c-4.5.0.0-48-g4dd794b3f" 
+        docker:             "us.gcr.io/broad-gatk/gatk:4.5.0.0"
     }
     RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
     runtime {
@@ -627,6 +624,7 @@ task ApplyBQSR {
             ~{true='--static-quantized-quals 10' false='' bin_base_qualities} \
             ~{true='--static-quantized-quals 20' false='' bin_base_qualities} \
             ~{true='--static-quantized-quals 30' false='' bin_base_qualities} \
+            --allow-missing-read-group true \
 
         # Make sure we use all our proocesors:
         np=$(cat /proc/cpuinfo | grep ^processor | tail -n1 | awk '{print $NF+1}')
@@ -641,7 +639,9 @@ task ApplyBQSR {
         boot_disk_gb:       10,
         preemptible_tries:  1,
         max_retries:        1,
-        docker:             "us.gcr.io/broad-gatk/gatk:4.5.0.0"
+        # docker:             "us.gcr.io/broad-gatk/gatk:4.5.0.0"
+        # Temporary snapshot build for testing the fix for BQSR issue https://github.com/broadinstitute/gatk/issues/6242
+        docker:             "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots/gatk-remote-builds:jonn-4dd794b3f4e4e4e6a86f309a5ea1b580bf774b7c-4.5.0.0-48-g4dd794b3f" 
     }
     RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
     runtime {

--- a/wdl/tasks/Utility/SRUtils.wdl
+++ b/wdl/tasks/Utility/SRUtils.wdl
@@ -290,15 +290,15 @@ task Bowtie2 {
 
         # Move the bowtie2 index files to the same directory as the reference fasta file:
         ref_dir=$(dirname ~{ref_fasta})
-        for f in ~{sep=" " ref_bowtie_indices} ; do
+        while read f ; do 
             indx_dirname=$( dirname ${f} )
             if [[ "${indx_dirname}" != "${ref_dir}" ]] ; then
                 mv ${f} ${ref_dir}
             fi
-        done
+        done < ~{write_lines(ref_bowtie_indices)}
 
         # Get the basename of the bowtie2 index file so we can reference it in the bowtie2 command:
-        bowtie2_index_basename=$(echo "~{ref_bowtie_indices[0]}" | grep bwt | head -n1 | sed 's@\.[a-zA-Z0-9]*\.bwt@@')
+        bowtie2_index_basename=$(echo "~{ref_bowtie_indices[0]}" | grep bt2 | head -n1 | sed 's@\.[a-zA-Z0-9]*\.bt2@@')
 
         echo "Aligning to genome:"
         bowtie2 -x ${bowtie2_index_basename} \

--- a/wdl/tasks/Utility/SRUtils.wdl
+++ b/wdl/tasks/Utility/SRUtils.wdl
@@ -308,7 +308,7 @@ task Bowtie2 {
             ~{rgid_cmd} "~{rg_id_val}" \
             ~{rg_cmd} "~{rg_pl_val}" \
             ~{rg_cmd} "~{rg_lb_val}" \
-            ~{rg_cmd} "~{rg_sm_val}" | \ 
+            ~{rg_cmd} "~{rg_sm_val}" | \
         samtools view -bh --no-PG - > tmp.bam
 
         # Now sort the output:

--- a/wdl/tasks/Utility/Utils.wdl
+++ b/wdl/tasks/Utility/Utils.wdl
@@ -66,14 +66,14 @@ task SortSam {
     parameter_meta {
         input_bam: "The BAM file to sort"
         output_bam_basename: "The basename for the output BAM file"
-        compression_level: "The compression level for the output BAM file"
+        compression_level: "The compression level for the output BAM file (default: 2)"
         runtime_attr_override: "Override the default runtime attributes"
     }
 
     input {
         File input_bam
         String output_bam_basename
-        Int compression_level
+        Int compression_level = 2
 
         RuntimeAttr? runtime_attr_override
     }

--- a/wdl/tasks/Utility/Utils.wdl
+++ b/wdl/tasks/Utility/Utils.wdl
@@ -82,7 +82,7 @@ task SortSam {
             np=$((np-1))
         fi
 
-        samtools sort -n -@ ${np} ~{input_bam} -o ~{prefix}.bam
+        samtools sort -@ ${np} ~{input_bam} -o ~{prefix}.bam
         samtools index -@ ${np} ~{prefix}.bam
     >>>
 

--- a/wdl/tasks/Utility/Utils.wdl
+++ b/wdl/tasks/Utility/Utils.wdl
@@ -1033,10 +1033,23 @@ task Index {
     String prefix = basename(bam)
 
     command <<<
+        ################################
+        # Standard Preamble
+
         set -euxo pipefail
 
+        # Make sure we use all our proocesors:
+        np=$(cat /proc/cpuinfo | grep ^processor | tail -n1 | awk '{print $NF+1}')
+        if [[ ${np} -gt 2 ]] ; then
+            let np=${np}-1
+        fi
+
+        tot_mem_mb=$(free -m | grep '^Mem' | awk '{print $2}')
+
+        ################################
+
         mv ~{bam} ~{prefix}
-        samtools index ~{basename(prefix)}
+        samtools index -@$((np-1)) ~{basename(prefix)}
     >>>
 
     output {

--- a/wdl/tasks/Z_One_Off_Analyses/BroadOnPremMalariaPipelineTasks.wdl
+++ b/wdl/tasks/Z_One_Off_Analyses/BroadOnPremMalariaPipelineTasks.wdl
@@ -16,6 +16,10 @@ task VariantRecalibrator {
         File resource_vcf_hb3_dd2
         File resource_vcf_3d7_hb3
 
+        File resource_vcf_3d7_hb3_index
+        File resource_vcf_hb3_dd2_index
+        File resource_vcf_7g8_gb4_index
+
         RuntimeAttr? runtime_attr_override
     }
 

--- a/wdl/tasks/Z_One_Off_Analyses/BroadOnPremMalariaPipelineTasks.wdl
+++ b/wdl/tasks/Z_One_Off_Analyses/BroadOnPremMalariaPipelineTasks.wdl
@@ -1,0 +1,188 @@
+version 1.0
+
+import "../../structs/Structs.wdl"
+
+task VariantRecalibrator {
+    input {
+        String prefix
+
+        File input_vcf
+
+        File reference_fasta
+        File reference_fai
+        File reference_dict
+
+        File resource_vcf_7g8_gb4
+        File resource_vcf_hb3_dd2
+        File resource_vcf_3d7_hb3
+
+        RuntimeAttr? runtime_attr_override
+    }
+
+    Int disk_size = 1 + 10*ceil(size([input_vcf, reference_fasta, resource_vcf_7g8_gb4, resource_vcf_hb3_dd2, resource_vcf_3d7_hb3], "GB"))
+
+    command <<<
+        ################################
+        # Standard Preamble
+
+        set -euxo pipefail
+
+        # Make sure we use all our proocesors:
+        np=$(cat /proc/cpuinfo | grep ^processor | tail -n1 | awk '{print $NF+1}')
+        if [[ ${np} -gt 2 ]] ; then
+            let np=${np}-1
+        fi
+
+        tot_mem_mb=$(free -m | grep '^Mem' | awk '{print $2}')
+
+        ################################
+
+        java_memory_size_mb=$((tot_mem_mb-5120))
+
+        java -Xmx${java_memory_size_mb}M -jar /usr/GenomeAnalysisTK.jar \
+            -T VariantRecalibrator \
+                -R ~{reference_fasta} \
+                -input ~{input_vcf} \
+                -mode SNP \
+                -resource:7g8_gb4,known=false,training=true,truth=true,prior=15.0 ~{resource_vcf_7g8_gb4} \
+                -resource:hb3_dd2,known=false,training=true,truth=true,prior=15.0 ~{resource_vcf_hb3_dd2} \
+                -resource:3d7_hb3,known=false,training=true,truth=true,prior=15.0 ~{resource_vcf_3d7_hb3} \
+                -recalFile ~{prefix}_CombinedGVCFs.snp.recal \
+                -tranchesFile ~{prefix}_CombinedGVCFs.snp.tranches \
+                -rscriptFile ~{prefix}_CombinedGVCFs.snp.plots.R \
+                -an QD \
+                -an FS \
+                -an SOR \
+                -an DP \
+                -an MQ \
+                --maxGaussians 8 \
+                --MQCapForLogitJitterTransform 70
+
+        java -Xmx${java_memory_size_mb}M -jar /usr/GenomeAnalysisTK.jar \
+            -T ApplyRecalibration \
+                -R ~{reference_fasta} \
+                -input ~{input_vcf} \
+                --ts_filter_level 99.5 \
+                -tranchesFile ~{prefix}_CombinedGVCFs.snp.tranches \
+                -recalFile ~{prefix}_CombinedGVCFs.snp.recal \
+                -mode SNP \
+                -o ~{prefix}.snp.recalibrated.vcf
+
+        java -Xmx${java_memory_size_mb}M -jar /usr/GenomeAnalysisTK.jar \
+            -T VariantRecalibrator \
+                -R ~{reference_fasta} \
+                -input ~{prefix}.snp.recalibrated.vcf \
+                -mode indel \
+                -resource:7g8_gb4,known=false,training=true,truth=true,prior=12.0 ~{resource_vcf_7g8_gb4} \
+                -resource:hb3_dd2,known=false,training=true,truth=true,prior=12.0 ~{resource_vcf_hb3_dd2} \
+                -resource:3d7_hb3,known=false,training=true,truth=true,prior=12.0 ~{resource_vcf_3d7_hb3} \
+                -recalFile ~{prefix}_CombinedGVCFs.snp.indel.recal \
+                -tranchesFile ~{prefix}_CombinedGVCFs.snp.indel.tranches \
+                -rscriptFile ~{prefix}_CombinedGVCFs.snp.indel.plots.R \
+                -an QD \
+                -an FS \
+                -an MQ \
+                --maxGaussians 4 \
+                --MQCapForLogitJitterTransform 70
+
+        java -Xmx${java_memory_size_mb}M -jar /usr/GenomeAnalysisTK.jar \
+            -T ApplyRecalibration \
+                -R ~{reference_fasta} \
+                -input ~{prefix}.snp.recalibrated.vcf \
+                --ts_filter_level 99.0 \
+                -tranchesFile ~{prefix}_CombinedGVCFs.snp.indel.tranches \
+                -recalFile ~{prefix}_CombinedGVCFs.snp.indel.recal \
+                -mode indel \
+                -o ~{prefix}.snp.indel.recalibrated.vcf
+
+        java -Xmx${java_memory_size_mb}M -jar /usr/GenomeAnalysisTK.jar \
+            -T VariantFiltration \
+                -R ~{reference_fasta} \
+                -V ~{prefix}.snp.indel.recalibrated.vcf \
+                --filterExpression "VQSLOD <= 0.0"\
+                --filterName "my_variant_filter" \
+                -o ~{prefix}.snp.indel.recalibrated.filtered.vcf
+    >>>
+
+    output {
+        File vcf = "~{prefix}.snp.indel.recalibrated.filtered.vcf"
+    }
+
+    #########################
+    RuntimeAttr default_attr = object {
+        cpu_cores:          2,
+        mem_gb:             16,
+        disk_gb:            disk_size,
+        boot_disk_gb:       10,
+        preemptible_tries:  1,
+        max_retries:        1,
+        docker:             "broadinstitute/gatk3:3.5-0"
+    }
+    RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
+    runtime {
+        cpu:                    select_first([runtime_attr.cpu_cores,         default_attr.cpu_cores])
+        memory:                 select_first([runtime_attr.mem_gb,            default_attr.mem_gb]) + " GiB"
+        disks: "local-disk " +  select_first([runtime_attr.disk_gb,           default_attr.disk_gb]) + " HDD"
+        bootDiskSizeGb:         select_first([runtime_attr.boot_disk_gb,      default_attr.boot_disk_gb])
+        preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
+        maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])
+        docker:                 select_first([runtime_attr.docker,            default_attr.docker])
+    }
+}
+
+task SortCompressIndexVcf {
+
+    input {
+        File input_vcf
+
+        RuntimeAttr? runtime_attr_override
+    }
+
+    Int disk_size = 10 + 10*ceil(size(input_vcf, "GB"))
+
+    command <<<
+        ################################
+        # Standard Preamble
+
+        set -euxo pipefail
+
+        # Make sure we use all our proocesors:
+        np=$(cat /proc/cpuinfo | grep ^processor | tail -n1 | awk '{print $NF+1}')
+        if [[ ${np} -gt 2 ]] ; then
+            let np=${np}-1
+        fi
+
+        tot_mem_mb=$(free -m | grep '^Mem' | awk '{print $2}')
+
+        ################################
+
+        bcftools sort -m$((tot_mem_mb-2048))M -Oz2 -o ~{input_vcf}.gz ~{input_vcf}
+        bcftools index --threads ${np} --tbi  ~{input_vcf}.gz
+    >>>
+
+    output {
+        File vcf = "~{input_vcf}.gz"
+        File vcf_index = "~{input_vcf}.gz.tbi"
+    }
+
+    #########################
+    RuntimeAttr default_attr = object {
+        cpu_cores:          2,
+        mem_gb:             16,
+        disk_gb:            disk_size,
+        boot_disk_gb:       10,
+        preemptible_tries:  1,
+        max_retries:        0,
+        docker:             "us.gcr.io/broad-dsp-lrma/lr-basic:0.1.2"
+    }
+    RuntimeAttr runtime_attr = select_first([runtime_attr_override, default_attr])
+    runtime {
+        cpu:                    select_first([runtime_attr.cpu_cores,         default_attr.cpu_cores])
+        memory:                 select_first([runtime_attr.mem_gb,            default_attr.mem_gb]) + " GiB"
+        disks: "local-disk " +  select_first([runtime_attr.disk_gb,           default_attr.disk_gb]) + " SSD"
+        bootDiskSizeGb:         select_first([runtime_attr.boot_disk_gb,      default_attr.boot_disk_gb])
+        preemptible:            select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
+        maxRetries:             select_first([runtime_attr.max_retries,       default_attr.max_retries])
+        docker:                 select_first([runtime_attr.docker,            default_attr.docker])
+    }
+}


### PR DESCRIPTION
This PR adds in WDL-ized versions of the Broad on-prem malaria pipelines so we can perform comparisons on them vs newer / alternative pipelines.

In addition, this PR includes updates to the main Malaria pipelines to filter out human reads from the input data.  This filtration uses the accepted `Bowtie2` alignment-based methods.  As tested, the reads are aligned to the T2T reference (`chm13`).