### PR TITLE
Fixed bug in some cases of QC failure in `QCAssessment.wdl`

### DIFF
--- a/wdl/tasks/QC/QCAssessment.wdl
+++ b/wdl/tasks/QC/QCAssessment.wdl
@@ -69,10 +69,12 @@ task AssessQualityMetrics {
         callable_frac=$(awk "BEGIN {printf(\"%.8f\", ${callable_bases}/${total_bases})}")
         callable_status=$(awk "BEGIN { if (${callable_frac} > ~{min_callable_fraction}) { print \"true\" } else { print \"false\" }}")
 
+        # Set blank default message:
+        message=""
+
         # Determine pass/fail status
         if $mosdepth_qc_status && $callable_status; then
             qc_status="Pass"
-            message=""
         else
             qc_status="Fail"
             # Now make a message so the user knows why QC failed:


### PR DESCRIPTION
- When $mosdepth_qc_status was true and $callable_status was false, there was a bug that caused an `unbound variable` exception (message had not been defined in that code path).