### PR TITLE
Updated `SRUtils.BamToFq` and `SRBamToFq` with cram support and better memory / cpu settings

### DIFF
--- a/wdl/pipelines/TechAgnostic/Utility/SRBamToFq.wdl
+++ b/wdl/pipelines/TechAgnostic/Utility/SRBamToFq.wdl
@@ -8,20 +8,22 @@ workflow SRBamToFq {
         File bam
         String participant_name
 
-        String gcs_out_root_dir
+        String? gcs_out_root_dir
     }
-
-    String outdir = sub(gcs_out_root_dir, "/$", "") + "/SRBamToFq/~{participant_name}"
 
     call SRUtils.BamToFq { input: bam = bam, prefix = participant_name }
 
-    call FF.FinalizeToFile as FinalizeFqEnd1 { input: outdir = outdir, file = BamToFq.fq_end1 }
-    call FF.FinalizeToFile as FinalizeFqEnd2 { input: outdir = outdir, file = BamToFq.fq_end2 }
-    call FF.FinalizeToFile as FinalizeFqUnpaired { input: outdir = outdir, file = BamToFq.fq_unpaired }
+    if (defined(gcs_out_root_dir)) {
+        String outdir = sub(select_first([gcs_out_root_dir]), "/$", "") + "/SRBamToFq/~{participant_name}"
+
+        call FF.FinalizeToFile as FinalizeFqEnd1 { input: outdir = outdir, file = BamToFq.fq_end1 }
+        call FF.FinalizeToFile as FinalizeFqEnd2 { input: outdir = outdir, file = BamToFq.fq_end2 }
+        call FF.FinalizeToFile as FinalizeFqUnpaired { input: outdir = outdir, file = BamToFq.fq_unpaired }
+    }
 
     output {
-        File fq_end1 = FinalizeFqEnd1.gcs_path
-        File fq_end2 = FinalizeFqEnd2.gcs_path
-        File fq_unpaired = FinalizeFqUnpaired.gcs_path
+        File fq_end1 = select_first([FinalizeFqEnd1.gcs_path, BamToFq.fq_end1])
+        File fq_end2 = select_first([FinalizeFqEnd2.gcs_path, BamToFq.fq_end2])
+        File fq_unpaired = select_first([FinalizeFqUnpaired.gcs_path, BamToFq.fq_unpaired])
     }
 }

--- a/wdl/pipelines/TechAgnostic/Utility/SRBamToFq.wdl
+++ b/wdl/pipelines/TechAgnostic/Utility/SRBamToFq.wdl
@@ -7,12 +7,25 @@ workflow SRBamToFq {
     input {
         File bam
         File? bam_index
+
+        File? reference_fasta
+        File? reference_fasta_index
+        File? reference_dict
+
         String participant_name
 
         String? gcs_out_root_dir
     }
 
-    call SRUtils.BamToFq { input: bam = bam, bam_index = bam_index, prefix = participant_name }
+    call SRUtils.BamToFq { 
+        input: 
+            bam = bam, 
+            bam_index = bam_index, 
+            reference_fasta = reference_fasta, 
+            reference_fasta_index = reference_fasta_index, 
+            reference_dict = reference_dict, 
+            prefix = participant_name 
+    }
 
     if (defined(gcs_out_root_dir)) {
         String outdir = sub(select_first([gcs_out_root_dir]), "/$", "") + "/SRBamToFq/~{participant_name}"

--- a/wdl/pipelines/TechAgnostic/Utility/SRBamToFq.wdl
+++ b/wdl/pipelines/TechAgnostic/Utility/SRBamToFq.wdl
@@ -6,12 +6,13 @@ import "../../../tasks/Utility/Finalize.wdl" as FF
 workflow SRBamToFq {
     input {
         File bam
+        File? bam_index
         String participant_name
 
         String? gcs_out_root_dir
     }
 
-    call SRUtils.BamToFq { input: bam = bam, prefix = participant_name }
+    call SRUtils.BamToFq { input: bam = bam, bam_index = bam_index, prefix = participant_name }
 
     if (defined(gcs_out_root_dir)) {
         String outdir = sub(select_first([gcs_out_root_dir]), "/$", "") + "/SRBamToFq/~{participant_name}"

--- a/wdl/tasks/Utility/SRUtils.wdl
+++ b/wdl/tasks/Utility/SRUtils.wdl
@@ -55,8 +55,8 @@ task BamToFq {
 
     #########################
     RuntimeAttr default_attr = object {
-        cpu_cores:          16,
-        mem_gb:             32,
+        cpu_cores:          8,
+        mem_gb:             16,
         disk_gb:            disk_size,
         boot_disk_gb:       25,
         preemptible_tries:  1,

--- a/wdl/tasks/Utility/SRUtils.wdl
+++ b/wdl/tasks/Utility/SRUtils.wdl
@@ -18,7 +18,7 @@ task BamToFq {
 
     String ref_arg = if defined(reference_fasta) then " --reference " else ""
 
-    Int disk_size = 1 + 20*ceil(size(bam, "GB"))
+    Int disk_size = 10 + 20*ceil(size(bam, "GB"))
 
     command <<<
 
@@ -55,8 +55,8 @@ task BamToFq {
 
     #########################
     RuntimeAttr default_attr = object {
-        cpu_cores:          8,
-        mem_gb:             24,
+        cpu_cores:          16,
+        mem_gb:             32,
         disk_gb:            disk_size,
         boot_disk_gb:       25,
         preemptible_tries:  1,

--- a/wdl/tasks/Utility/SRUtils.wdl
+++ b/wdl/tasks/Utility/SRUtils.wdl
@@ -18,18 +18,33 @@ task BamToFq {
 
     String ref_arg = if defined(reference_fasta) then " --reference " else ""
 
-    Int disk_size = 1 + 4*ceil(size(bam, "GB"))
+    Int disk_size = 1 + 20*ceil(size(bam, "GB"))
 
     command <<<
+
+        # Make sure we use all our proocesors:
+        np=$(cat /proc/cpuinfo | grep ^processor | tail -n1 | awk '{print $NF+1}')
+        if [[ ${np} -gt 2 ]] ; then
+            np=$((np-1))
+        fi
+
         set -euxo pipefail
 
-        samtools sort -n ~{ref_arg} ~{reference_fasta} ~{bam} | samtools bam2fq -@2 \
+        # Have samtools sort use all but one of our processors:
+        # NOTE: the `@` options is for ADDITIONAL threads, not the total number of threads.
+        samtools sort -@$((np-1)) -n ~{ref_arg} ~{reference_fasta} ~{bam} -O bam -o tmp.bam
+        
+        # Have samtools bam2fq use all but one of our processors:
+        # NOTE: the `@` options is for ADDITIONAL threads, not the total number of threads.
+        samtools bam2fq -@$((np-1)) \
             -n \
             -s /dev/null \
+            -c 2 \
             ~{ref_arg} ~{reference_fasta} \
             -1 ~{prefix}.end1.fq.gz \
             -2 ~{prefix}.end2.fq.gz \
-            -0 ~{prefix}.unpaired.fq.gz
+            -0 ~{prefix}.unpaired.fq.gz \
+            tmp.bam
     >>>
 
     output {
@@ -40,8 +55,8 @@ task BamToFq {
 
     #########################
     RuntimeAttr default_attr = object {
-        cpu_cores:          4,
-        mem_gb:             32,
+        cpu_cores:          8,
+        mem_gb:             24,
         disk_gb:            disk_size,
         boot_disk_gb:       25,
         preemptible_tries:  1,

--- a/wdl/tasks/Utility/SRUtils.wdl
+++ b/wdl/tasks/Utility/SRUtils.wdl
@@ -5,6 +5,7 @@ import "../../structs/Structs.wdl"
 task BamToFq {
     input {
         File bam
+        File? bam_index
         String prefix = "out"
 
         RuntimeAttr? runtime_attr_override

--- a/wdl/tasks/Utility/SRUtils.wdl
+++ b/wdl/tasks/Utility/SRUtils.wdl
@@ -23,7 +23,7 @@ task BamToFq {
     command <<<
         set -euxo pipefail
 
-        samtools sort -n ~{bam} | samtools -@2 bam2fq \
+        samtools sort -n ~{bam} | samtools bam2fq -@2 \
             -n \
             -s /dev/null \
             ~{ref_arg}'~{reference_fasta}' \

--- a/wdl/tasks/Utility/SRUtils.wdl
+++ b/wdl/tasks/Utility/SRUtils.wdl
@@ -26,7 +26,7 @@ task BamToFq {
         samtools sort -n ~{ref_arg} ~{bam} | samtools bam2fq -@2 \
             -n \
             -s /dev/null \
-            ~{ref_arg}'~{reference_fasta}' \
+            ~{ref_arg} \
             -1 ~{prefix}.end1.fq.gz \
             -2 ~{prefix}.end2.fq.gz \
             -0 ~{prefix}.unpaired.fq.gz

--- a/wdl/tasks/Utility/SRUtils.wdl
+++ b/wdl/tasks/Utility/SRUtils.wdl
@@ -23,7 +23,7 @@ task BamToFq {
     command <<<
         set -euxo pipefail
 
-        samtools sort -n ~{bam} | samtools bam2fq -@2 \
+        samtools sort -n ~{ref_arg} ~{bam} | samtools bam2fq -@2 \
             -n \
             -s /dev/null \
             ~{ref_arg}'~{reference_fasta}' \

--- a/wdl/tasks/Utility/SRUtils.wdl
+++ b/wdl/tasks/Utility/SRUtils.wdl
@@ -16,7 +16,7 @@ task BamToFq {
         RuntimeAttr? runtime_attr_override
     }
 
-    String ref_arg = if defined(reference_fasta) then " --reference " + select_first([reference_fasta]) else ""
+    String ref_arg = if defined(reference_fasta) then " --reference ~{reference_fasta}" else ""
 
     Int disk_size = 1 + 4*ceil(size(bam, "GB"))
 

--- a/wdl/tasks/Utility/SRUtils.wdl
+++ b/wdl/tasks/Utility/SRUtils.wdl
@@ -16,17 +16,17 @@ task BamToFq {
         RuntimeAttr? runtime_attr_override
     }
 
-    String ref_arg = if defined(reference_fasta) then " --reference ~{reference_fasta}" else ""
+    String ref_arg = if defined(reference_fasta) then " --reference " else ""
 
     Int disk_size = 1 + 4*ceil(size(bam, "GB"))
 
     command <<<
         set -euxo pipefail
 
-        samtools sort -n ~{ref_arg} ~{bam} | samtools bam2fq -@2 \
+        samtools sort -n ~{ref_arg} ~{reference_fasta} ~{bam} | samtools bam2fq -@2 \
             -n \
             -s /dev/null \
-            ~{ref_arg} \
+            ~{ref_arg} ~{reference_fasta} \
             -1 ~{prefix}.end1.fq.gz \
             -2 ~{prefix}.end2.fq.gz \
             -0 ~{prefix}.unpaired.fq.gz


### PR DESCRIPTION
- Added optional reference inputs to `SRUtils.BamToFq` and `SRBamToFq` to support CRAM files.
- Tuned the CPU / Memory of `SRUtils.BamToFq` to better reflect real-world load.