### PR TITLE
`SRJointCallGVCFsWithGenomicsDB.wdl` now prefers `dbsnp_vcf` to `known_sites_vcf` for genotyping

### DIFF
--- a/wdl/pipelines/TechAgnostic/VariantCalling/SRJointCallGVCFsWithGenomicsDB.wdl
+++ b/wdl/pipelines/TechAgnostic/VariantCalling/SRJointCallGVCFsWithGenomicsDB.wdl
@@ -116,7 +116,12 @@ workflow SRJointCallGVCFsWithGenomicsDB {
     Map[String, String] ref_map = read_map(ref_map_file)
 
     # Resolve the db_snp_vcf file, with preference to the db_snp_vcf file if it exists:
-    File db_snp_vcf = select_first([ref_map["db_snp_vcf"], ref_map["known_sites_vcf"]])
+    call UTILS.ResolveMapKeysInPriorityOrder as ResolveMapKeysInPriorityOrder {
+        input:
+            map = ref_map,
+            keys = ["test_bad_key_should_not_be_found", "dbsnp_vcf", "known_sites_vcf"]
+    }
+    File db_snp_vcf = ref_map[ResolveMapKeysInPriorityOrder.key]
 
     # Create sample-name map:
     call SRJOINT.CreateSampleNameMap as CreateSampleNameMap {

--- a/wdl/pipelines/TechAgnostic/VariantCalling/SRJointCallGVCFsWithGenomicsDB.wdl
+++ b/wdl/pipelines/TechAgnostic/VariantCalling/SRJointCallGVCFsWithGenomicsDB.wdl
@@ -115,6 +115,9 @@ workflow SRJointCallGVCFsWithGenomicsDB {
 
     Map[String, String] ref_map = read_map(ref_map_file)
 
+    # Resolve the db_snp_vcf file, with preference to the db_snp_vcf file if it exists:
+    File db_snp_vcf = select_first([ref_map["db_snp_vcf"], ref_map["known_sites_vcf"]])
+
     # Create sample-name map:
     call SRJOINT.CreateSampleNameMap as CreateSampleNameMap {
         input:
@@ -178,7 +181,7 @@ workflow SRJointCallGVCFsWithGenomicsDB {
                     ref_fasta       = ref_map['fasta'],
                     ref_fasta_fai   = ref_map['fai'],
                     ref_dict        = ref_map['dict'],
-                    dbsnp_vcf       = ref_map["known_sites_vcf"],
+                    dbsnp_vcf       = db_snp_vcf,
                     prefix          = prefix + "." + interval_name + ".gnarly_genotyper.raw",
                     heterozygosity = heterozygosity,
                     heterozygosity_stdev = heterozygosity_stdev,
@@ -194,7 +197,7 @@ workflow SRJointCallGVCFsWithGenomicsDB {
                     ref_fasta       = ref_map['fasta'],
                     ref_fasta_fai   = ref_map['fai'],
                     ref_dict        = ref_map['dict'],
-                    dbsnp_vcf       = ref_map["known_sites_vcf"],
+                    dbsnp_vcf       = db_snp_vcf,
                     prefix          = prefix + "." + interval_name + ".genotype_gvcfs.raw",
                     heterozygosity = heterozygosity,
                     heterozygosity_stdev = heterozygosity_stdev,


### PR DESCRIPTION
- Added `ResolveMapKeysInPriorityOrder` to resolve keys in a WDL `Map` object in priority order.  This enables fallbacks / preferences for different entries in a map (such as the refmap).
- For genotyping with the gnarly genotyper, the dbsnp resource now prefers `dbsnp_vcf` from the RefMap.  If this does not exist, it will fall back to `known_sites_vcf`.  This allows different resources to be used for BQSR (which prefers `known_sites_vcf` in SRFlowcell) and the gnarly genotyper, which now prefers `dbsnp_vcf`.