### PR TITLE
Updated pip cache step to version 4

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -33,7 +33,7 @@ jobs:
           sudo apt install libbz2-dev liblzma-dev libcurl4-openssl-dev libssl-dev
 
       - name: Cache pip
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}

--- a/.github/workflows/ci_nightly.yml
+++ b/.github/workflows/ci_nightly.yml
@@ -33,7 +33,7 @@ jobs:
           sudo apt install libbz2-dev liblzma-dev libcurl4-openssl-dev libssl-dev
 
       - name: Cache pip
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}

--- a/.github/workflows/ci_push.yml
+++ b/.github/workflows/ci_push.yml
@@ -33,7 +33,7 @@ jobs:
         sudo apt install libbz2-dev liblzma-dev libcurl4-openssl-dev libssl-dev
 
     - name: Cache pip
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}

--- a/.github/workflows/git_page.yml
+++ b/.github/workflows/git_page.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Cache node_modules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/validate_dockstore_yaml.yml
+++ b/.github/workflows/validate_dockstore_yaml.yml
@@ -14,7 +14,7 @@ jobs:
                 java-version: '17'
 
             - name: Cache node_modules
-              uses: actions/cache@v2
+              uses: actions/cache@v4
               with:
                 path: "**/node_modules"
                 key: ${{ runner.os }}-modules-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION
Received errors during CI :

> “Your workflow is using a version of actions/cache that is scheduled for deprecation, actions/cache@v2. Please update your workflow to use either v3 or v4 of actions/cache to avoid interruptions.” 

(https://github.com/broadinstitute/long-read-pipelines/actions/runs/13266038546)

So updated the action version to the latest version (4).