### PR TITLE
Added minimum for miniwdl version to use

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -46,7 +46,7 @@ jobs:
           pip install -r requirements.txt
           $CONDA/bin/conda install -y -c bioconda womtool
           $CONDA/bin/conda config --add channels conda-forge
-          $CONDA/bin/conda install -y -c conda-forge miniwdl shellcheck
+          $CONDA/bin/conda install -y -c conda-forge "miniwdl>=1.12.1" shellcheck
           echo "$CONDA/bin" >> $GITHUB_PATH
 
       - name: Test with tox

--- a/.github/workflows/ci_nightly.yml
+++ b/.github/workflows/ci_nightly.yml
@@ -46,7 +46,7 @@ jobs:
           pip install -r requirements.txt
           $CONDA/bin/conda install -y -c bioconda womtool
           $CONDA/bin/conda config --add channels conda-forge
-          $CONDA/bin/conda install -y -c conda-forge miniwdl shellcheck
+          $CONDA/bin/conda install -y -c conda-forge "miniwdl>=1.12.1" shellcheck
           echo "$CONDA/bin" >> $GITHUB_PATH
 
       - name: Test with tox

--- a/.github/workflows/ci_push.yml
+++ b/.github/workflows/ci_push.yml
@@ -46,7 +46,7 @@ jobs:
         pip install -r requirements.txt
         $CONDA/bin/conda install -y -c bioconda womtool 
         $CONDA/bin/conda config --add channels conda-forge
-        $CONDA/bin/conda install -y -c conda-forge miniwdl shellcheck
+        $CONDA/bin/conda install -y -c conda-forge "miniwdl>=1.12.1" shellcheck
         echo "$CONDA/bin" >> $GITHUB_PATH
 
     - name: Test with tox


### PR DESCRIPTION
Conda has been observed to install older versions of miniwdl, which have outdated linting capabilities. This can lead to validation errors, as seen in this example: [link](https://github.com/broadinstitute/long-read-pipelines/actions/runs/13302204182/job/37145532001). 
This PR specifies a minimum miniwdl version of 1.12.1 for WDL validation to ensure access to up-to-date linting features and avoid these errors.
