### PR TITLE
New release of lr-basic (0.1.2)

### DIFF
--- a/docker/lr-basic/Dockerfile
+++ b/docker/lr-basic/Dockerfile
@@ -1,11 +1,11 @@
 # some basic bioinformatics utilities.
 
 ############### stage 0: build samtools and bcftools from source
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
-ARG SAMTOOLS_VERSION=1.13
-ARG BCFTOOLS_VERSION=1.13
+ARG SAMTOOLS_VERSION=1.22.1
+ARG BCFTOOLS_VERSION=1.22
 RUN apt-get -qqy update --fix-missing && \
     apt-get -qqy dist-upgrade && \
     apt-get -qqy install --no-install-recommends \
@@ -41,7 +41,7 @@ RUN apt-get -qqy update --fix-missing && \
     bcftools --help
 
 ############### stage 1: other commonly used bioinformatics utilities 
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 ENV HOME=/root
 

--- a/docker/lr-basic/Makefile
+++ b/docker/lr-basic/Makefile
@@ -1,4 +1,4 @@
-VERSION = 0.1.1
+VERSION = 0.1.2
 TAG1 = us.gcr.io/broad-dsp-lrma/lr-basic:$(VERSION)
 TAG2 = us.gcr.io/broad-dsp-lrma/lr-basic:latest
 


### PR DESCRIPTION
- Several updates to `lr-basic` docker image.
  - Updated base docker image to ubuntu:22.04.
  - Updated samtools to 1.22.1
  - Updated bcftools to 1.22
  - Incremented lr-basic docker image version to 0.1.2