### PR TITLE
Pulled out default runtime attrs from call to `GnarlyGenotyper`

### DIFF
--- a/wdl/pipelines/TechAgnostic/VariantCalling/SRJointCallGVCFsWithGenomicsDBPopulationScale.wdl
+++ b/wdl/pipelines/TechAgnostic/VariantCalling/SRJointCallGVCFsWithGenomicsDBPopulationScale.wdl
@@ -194,7 +194,8 @@ workflow SRJointCallGVCFsWithGenomicsDBPopulationScale {
                 heterozygosity = heterozygosity,
                 heterozygosity_stdev = heterozygosity_stdev,
                 indel_heterozygosity = indel_heterozygosity,
-                runtime_attr_override = object {preemptible_tries: 0},  # Disable preemption for prototype.
+              # runtime_attr_override = object {preemptible_tries: 0},  # Disable preemption for prototype.
+
         }
         # Select the VCF + index for the raw joint called file:
         File joint_vcf = GnarlyJointCallGVCFs.output_vcf


### PR DESCRIPTION
Tested on ~30000 Plasmodium falciparum samples.