### PR TITLE
Expose VQSR tuning knobs on the on-prem malaria joint-calling pipeline

### DIFF
--- a/wdl/pipelines/Z_One_Off_Analyses/BroadOnPremMalariaPipeline_2_JointVariantCalling.wdl
+++ b/wdl/pipelines/Z_One_Off_Analyses/BroadOnPremMalariaPipeline_2_JointVariantCalling.wdl
@@ -20,6 +20,14 @@ workflow BroadOnPremMalariaPipeline_2_JointVariantCalling {
         File resource_vcf_7g8_gb4
         File resource_vcf_hb3_dd2
         File resource_vcf_3d7_hb3
+
+        # VQSR model-fitting knobs (see VariantRecalibrator); defaults preserve
+        # prior behavior. Tune for small callsets where the negative model finds
+        # no "bad" variants (e.g. bad_lod_cutoff -> -2.0, snp_max_gaussians -> 4).
+        Int snp_max_gaussians = 8
+        Int indel_max_gaussians = 4
+        Int min_num_bad_variants = 1000
+        Float bad_lod_cutoff = -5.0
     }
 
     # Get ref info:
@@ -44,7 +52,11 @@ workflow BroadOnPremMalariaPipeline_2_JointVariantCalling {
             reference_dict = ref_map["dict"],
             resource_vcf_7g8_gb4 = resource_vcf_7g8_gb4,
             resource_vcf_hb3_dd2 = resource_vcf_hb3_dd2,
-            resource_vcf_3d7_hb3 = resource_vcf_3d7_hb3
+            resource_vcf_3d7_hb3 = resource_vcf_3d7_hb3,
+            snp_max_gaussians = snp_max_gaussians,
+            indel_max_gaussians = indel_max_gaussians,
+            min_num_bad_variants = min_num_bad_variants,
+            bad_lod_cutoff = bad_lod_cutoff
     }
 
     # 9 - sort, compress, and index final outputs:

--- a/wdl/tasks/Z_One_Off_Analyses/BroadOnPremMalariaPipelineTasks.wdl
+++ b/wdl/tasks/Z_One_Off_Analyses/BroadOnPremMalariaPipelineTasks.wdl
@@ -3,6 +3,18 @@ version 1.0
 import "../../structs/Structs.wdl"
 
 task VariantRecalibrator {
+    meta {
+        description: "Run GATK VariantRecalibrator/ApplyRecalibration (VQSR) over the joint-call VCF for SNPs then indels. The VQSR model-fitting knobs are exposed so small callsets (where the negative model can otherwise find no 'bad' variants) can be tuned at runtime."
+    }
+
+    parameter_meta {
+        snp_max_gaussians:    "SNP model --maxGaussians (default 8). Lower it for small callsets that cannot support 8 Gaussians."
+        indel_max_gaussians:  "Indel model --maxGaussians (default 4)."
+        min_num_bad_variants: "--minNumBadVariants for both models (GATK default 1000). Lower to accept a small negative training set."
+        bad_lod_cutoff:       "--badLodCutoff for both models (GATK default -5.0). Raise toward 0 (e.g. -2.0) so more variants enter the negative training set when none score below -5."
+        runtime_attr_override: "Override default runtime attributes."
+    }
+
     input {
         String prefix
 
@@ -19,6 +31,11 @@ task VariantRecalibrator {
         File resource_vcf_3d7_hb3_index
         File resource_vcf_hb3_dd2_index
         File resource_vcf_7g8_gb4_index
+
+        Int snp_max_gaussians = 8
+        Int indel_max_gaussians = 4
+        Int min_num_bad_variants = 1000
+        Float bad_lod_cutoff = -5.0
 
         RuntimeAttr? runtime_attr_override
     }
@@ -59,7 +76,9 @@ task VariantRecalibrator {
                 -an SOR \
                 -an DP \
                 -an MQ \
-                --maxGaussians 8 \
+                --maxGaussians ~{snp_max_gaussians} \
+                --minNumBadVariants ~{min_num_bad_variants} \
+                --badLodCutoff ~{bad_lod_cutoff} \
                 --MQCapForLogitJitterTransform 70
 
         java -Xmx${java_memory_size_mb}M -jar /usr/GenomeAnalysisTK.jar \
@@ -86,7 +105,9 @@ task VariantRecalibrator {
                 -an QD \
                 -an FS \
                 -an MQ \
-                --maxGaussians 4 \
+                --maxGaussians ~{indel_max_gaussians} \
+                --minNumBadVariants ~{min_num_bad_variants} \
+                --badLodCutoff ~{bad_lod_cutoff} \
                 --MQCapForLogitJitterTransform 70
 
         java -Xmx${java_memory_size_mb}M -jar /usr/GenomeAnalysisTK.jar \


### PR DESCRIPTION
VariantRecalibrator (VQSR) in BroadOnPremMalariaPipeline_2_JointVariantCalling
hardcoded its model-fitting parameters. On small callsets — e.g. the
sr_fiddock_crosses_deeptrio truth set (~34 samples) — the negative ("bad")
model finds no variants below the default badLodCutoff of -5.0 and GATK dies
with "No data found", so the whole joint-calling run fails.

This surfaces the relevant VQSR parameters as runtime inputs so such callsets
can be tuned from the method config without editing the WDL:

- snp_max_gaussians    -> SNP model --maxGaussians         (default 8)
- indel_max_gaussians  -> indel model --maxGaussians       (default 4)
- min_num_bad_variants -> both models --minNumBadVariants  (default 1000)
- bad_lod_cutoff       -> both models --badLodCutoff       (default -5.0)

Defaults reproduce the previous hardcoded behavior exactly (1000 and -5.0 are
GATK's own defaults; maxGaussians unchanged), so existing runs are unaffected.
Small cohorts can now, for example, set bad_lod_cutoff=-2.0, snp_max_gaussians=4,
min_num_bad_variants=100 to let the negative model train.

Inputs are added to the VariantRecalibrator task
(wdl/tasks/Z_One_Off_Analyses/BroadOnPremMalariaPipelineTasks.wdl) and threaded
through the workflow
(wdl/pipelines/Z_One_Off_Analyses/BroadOnPremMalariaPipeline_2_JointVariantCalling.wdl).
Validated with womtool and miniwdl.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>