### PR TITLE
P. falciparum variant-calling: small-genome benchmarking + Pf7 reimplementation pipelines

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -225,3 +225,9 @@ workflows:
 - name: SaigeMetaStratified
   subclass: wdl
   primaryDescriptorPath: /wdl/pipelines/TechAgnostic/Association/SaigeMetaStratified.wdl
+- name: Pf7JointGenotyping
+  subclass: wdl
+  primaryDescriptorPath: /wdl/pipelines/Z_One_Off_Analyses/Pf7JointGenotyping.wdl
+- name: Pf7SingleSampleVariantCalling
+  subclass: wdl
+  primaryDescriptorPath: /wdl/pipelines/Z_One_Off_Analyses/Pf7SingleSampleVariantCalling.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -117,6 +117,9 @@ workflows:
 - name: BenchmarkVCFs
   subclass: wdl
   primaryDescriptorPath: /wdl/pipelines/TechAgnostic/Utility/BenchmarkVCFs.wdl
+- name: BenchmarkVCFsSmall
+  subclass: wdl
+  primaryDescriptorPath: /wdl/pipelines/TechAgnostic/Utility/BenchmarkVCFsSmall.wdl
 - name: CompareVcfBenchmarks
   subclass: wdl
   primaryDescriptorPath: /wdl/pipelines/TechAgnostic/Utility/CompareVcfBenchmarks.wdl

--- a/wdl/pipelines/TechAgnostic/Utility/BenchmarkVCFsSmall.wdl
+++ b/wdl/pipelines/TechAgnostic/Utility/BenchmarkVCFsSmall.wdl
@@ -1124,7 +1124,12 @@ task EvalIndelLengthAllBins {
             fn="$(gatk --java-options "-Xmx~{memoryJava}G" CountVariants -V "sel.${label}.FN.vcf.gz" | tail -1)"
             fp="$(gatk --java-options "-Xmx~{memoryJava}G" CountVariants -V "sel.${label}.FP.vcf.gz" | tail -1)"
             printf '%s\t%s\t%s\t%s\t%s\n' "${label}" "${tpc}" "${tpb}" "${fn}" "${fp}" > "bin_counts/${label}.txt"
+            # Progress line (grep 'PROGRESS:' in this task's stderr to monitor).
+            echo "$(date -u '+%H:%M:%S') PROGRESS: $(find bin_counts -type f | wc -l)/${TOTAL_BINS} indel bins complete (last: ${label})" >&2
         }
+
+        TOTAL_BINS="$(grep -cve '^[[:space:]]*$' bins.tsv)"
+        echo "$(date -u '+%H:%M:%S') PROGRESS: starting ${TOTAL_BINS} indel bins across ~{cpu} workers" >&2
 
         # Run bins concurrently, bounded to ~{cpu} workers (a failed worker
         # propagates via `wait -n` under `set -e`).

--- a/wdl/pipelines/TechAgnostic/Utility/BenchmarkVCFsSmall.wdl
+++ b/wdl/pipelines/TechAgnostic/Utility/BenchmarkVCFsSmall.wdl
@@ -282,6 +282,35 @@ workflow BenchmarkVCFsSmall {
                     gatkTag = gatkTag,
                     preemptible = preemptible
             }
+
+            # Small-genome variant: loop all 55 indel-length bins inside one
+            # right-sized VM instead of fanning them into ~165 tiny VMs.
+            if (doIndelLengthStratification) {
+                call EvalIndelLengthAllBins {
+                    input:
+                        vcf = StandardVcfEval.outVcf,
+                        vcfIndex = StandardVcfEval.outVcfIndex,
+                        indelLabels = indelLabels,
+                        indelJexl = indelJexl,
+                        selectTPCall="CALL == 'TP'",
+                        selectTPBase="BASE == 'TP'",
+                        selectFN="(BASE == 'FN' || BASE == 'FN_CA')",
+                        selectFP="(CALL == 'FP' || CALL == 'FP_CA')",
+                        sampleCall="CALLS",
+                        sampleBase="BASELINE",
+                        engine="VcfEval",
+                        evalLabel = evalLabel,
+                        truthLabel = truthLabel,
+                        stratLabel = stratLabel,
+                        gatkTag = gatkTag,
+                        gatkJarForAnnotation = gatkJarForAnnotation,
+                        annotationNames = annotationNames,
+                        reference = ref_map["fasta"],
+                        refDict = ref_map["dict"],
+                        refIndex = ref_map["fai"],
+                        preemptible = preemptible
+                }
+            }
         }
 
         String areVariants = if(CheckForVariantsTruth.variantsFound && CheckForVariantsEval.variantsFound) then "yes" else "no"
@@ -312,38 +341,6 @@ workflow BenchmarkVCFsSmall {
     }
 
 
-    # Small-genome variant: instead of fanning the 55 indel-length bins into
-    # 55 x (Eval + WriteXML + Summarise) tasks per eval-combo (which dominates
-    # cost via VM startup/RAM-hours), loop all bins inside a single right-sized
-    # task per eval-combo. One VM does what ~165 VMs did.
-    scatter (annotatedVcfs in annotatedVcfsList) {
-        if (defined(annotatedVcfs.vcfVcfEval) && defined(annotatedVcfs.vcfVcfEvalIndex) && doIndelLengthStratification) {
-            call EvalIndelLengthAllBins {
-                input:
-                    vcf = annotatedVcfs.vcfVcfEval,
-                    vcfIndex = annotatedVcfs.vcfVcfEvalIndex,
-                    indelLabels = indelLabels,
-                    indelJexl = indelJexl,
-                    selectTPCall="CALL == 'TP'",
-                    selectTPBase="BASE == 'TP'",
-                    selectFN="(BASE == 'FN' || BASE == 'FN_CA')",
-                    selectFP="(CALL == 'FP' || CALL == 'FP_CA')",
-                    sampleCall="CALLS",
-                    sampleBase="BASELINE",
-                    engine="VcfEval",
-                    evalLabel = annotatedVcfs.evalLabel,
-                    truthLabel = annotatedVcfs.truthLabel,
-                    stratLabel = annotatedVcfs.stratLabel,
-                    gatkTag = gatkTag,
-                    gatkJarForAnnotation = gatkJarForAnnotation,
-                    annotationNames = annotationNames,
-                    reference = ref_map["fasta"],
-                    refDict = ref_map["dict"],
-                    refIndex = ref_map["fai"],
-                    preemptible = preemptible
-            }
-        }
-    }
 
 
 

--- a/wdl/pipelines/TechAgnostic/Utility/BenchmarkVCFsSmall.wdl
+++ b/wdl/pipelines/TechAgnostic/Utility/BenchmarkVCFsSmall.wdl
@@ -1145,8 +1145,13 @@ task EvalIndelLengthAllBins {
             exit 1
         fi
 
+        # Assemble in bins.tsv order (not glob/lexical order) so the row order is
+        # independent of concurrency and matches the serial version.
         printf 'label\ttp_call\ttp_base\tfn\tfp\n' > counts.tsv
-        cat bin_counts/*.txt >> counts.tsv
+        while IFS=$'\t' read -r label jexl; do
+            [ -z "${label}" ] && continue
+            cat "bin_counts/${label}.txt" >> counts.tsv
+        done < bins.tsv
 
         # Summarise all bins into one CSV (schema matches SummariseForIndelSelection).
         # IndelLength parsing mirrors that task's GetSelectionValue: NA for the

--- a/wdl/pipelines/TechAgnostic/Utility/BenchmarkVCFsSmall.wdl
+++ b/wdl/pipelines/TechAgnostic/Utility/BenchmarkVCFsSmall.wdl
@@ -1104,7 +1104,10 @@ task EvalIndelLengthAllBins {
         # Pre-filter to simple indels ONCE (keeping both samples). Every per-bin
         # selection then scans this small file instead of re-scanning the full,
         # potentially hundreds-of-thousands-of-variant, eval VCF 4x per bin.
-        gatk --java-options "-Xmx~{memoryJava}G" SelectVariants -V "${VCF}" -O indels.vcf.gz -select "vc.isSimpleIndel()"
+        # These intermediates are only counted (never region-queried), so skip
+        # output index creation: GATK 4.0.11 otherwise crashes writing the tabix
+        # index for empty / contig-sparse subsets (sequenceNames.size() mismatch).
+        gatk --java-options "-Xmx~{memoryJava}G" SelectVariants -V "${VCF}" -O indels.vcf.gz -select "vc.isSimpleIndel()" --create-output-variant-index false
 
         # One line per indel-length bin: <label>\t<jexl>
         paste "~{write_lines(indelLabels)}" "~{write_lines(indelJexl)}" > bins.tsv
@@ -1114,10 +1117,10 @@ task EvalIndelLengthAllBins {
         # uniquely-named file so concurrent workers never race.
         run_bin() {
             local label="$1" jexl="$2"
-            gatk --java-options "-Xmx~{memoryJava}G" SelectVariants -V indels.vcf.gz -O "sel.${label}.TP_CALL.vcf.gz" -select "${jexl} && ~{selectTPCall}" -sn ~{sampleCall}
-            gatk --java-options "-Xmx~{memoryJava}G" SelectVariants -V indels.vcf.gz -O "sel.${label}.TP_BASE.vcf.gz" -select "${jexl} && ~{selectTPBase}" -sn ~{sampleBase}
-            gatk --java-options "-Xmx~{memoryJava}G" SelectVariants -V indels.vcf.gz -O "sel.${label}.FN.vcf.gz" -select "${jexl} && ~{selectFN}" -sn ~{sampleBase}
-            gatk --java-options "-Xmx~{memoryJava}G" SelectVariants -V indels.vcf.gz -O "sel.${label}.FP.vcf.gz" -select "${jexl} && ~{selectFP}" -sn ~{sampleCall}
+            gatk --java-options "-Xmx~{memoryJava}G" SelectVariants -V indels.vcf.gz -O "sel.${label}.TP_CALL.vcf.gz" -select "${jexl} && ~{selectTPCall}" -sn ~{sampleCall} --create-output-variant-index false
+            gatk --java-options "-Xmx~{memoryJava}G" SelectVariants -V indels.vcf.gz -O "sel.${label}.TP_BASE.vcf.gz" -select "${jexl} && ~{selectTPBase}" -sn ~{sampleBase} --create-output-variant-index false
+            gatk --java-options "-Xmx~{memoryJava}G" SelectVariants -V indels.vcf.gz -O "sel.${label}.FN.vcf.gz" -select "${jexl} && ~{selectFN}" -sn ~{sampleBase} --create-output-variant-index false
+            gatk --java-options "-Xmx~{memoryJava}G" SelectVariants -V indels.vcf.gz -O "sel.${label}.FP.vcf.gz" -select "${jexl} && ~{selectFP}" -sn ~{sampleCall} --create-output-variant-index false
             local tpc tpb fn fp
             tpc="$(gatk --java-options "-Xmx~{memoryJava}G" CountVariants -V "sel.${label}.TP_CALL.vcf.gz" | tail -1)"
             tpb="$(gatk --java-options "-Xmx~{memoryJava}G" CountVariants -V "sel.${label}.TP_BASE.vcf.gz" | tail -1)"

--- a/wdl/pipelines/TechAgnostic/Utility/BenchmarkVCFsSmall.wdl
+++ b/wdl/pipelines/TechAgnostic/Utility/BenchmarkVCFsSmall.wdl
@@ -1,0 +1,1652 @@
+version 1.0
+
+workflow BenchmarkVCFsSmall {
+
+    meta {
+        description: "A workflow to calculate sensitivity and precision of a germline variant calling pipeline by comparing a 'call' vcf produced by the pipeline to a gold standard 'truth' vcf.  Allows for stratification based on interval lists, bed files, or variant types defined according to GATK SelectVariants.  Borrowed and adapted from the Broad Institute's Hydrogen/Palantir repo, courtesy of Michael Gatzen (https://github.com/broadinstitute/palantir-workflows/tree/mg_benchmark_compare/BenchmarkVCFs ; permalink: https://github.com/broadinstitute/palantir-workflows/blob/0bf48efc6de818364993e46d89591a035cfd80c7/BenchmarkVCFs/BenchmarkVCFs.wdl)."
+    }
+
+    parameter_meta {
+        evalVcf: {description: "vcfs to be evaluated"}
+        evalLabel: {description: "label to identify vcf to be evaluated"}
+        evalVcfIndex: {description: "vcf index for evalVcf"}
+        evalBam: {description: "bam file contaning the reads that generated the evalVcf"}
+        evalBamLabel: {description: "label to use for the evalBam in IGV"}
+        truthVcf: {description: "truth vcf against which to evaluate"}
+        truthLabel: {description: "label by which to indentify truth set"}
+        truthBam: {description: "bam file contaning the reads that generated the truthVcf"}
+        truthBamLabel: {description: "label to use for the truthBam in IGV"}
+        confidenceInterval: {description: "confidence interval for truth set (can be bed or picard interval_list)"}
+        ref_map_file: {description: "table indicating reference sequence and auxillary file locations" }
+        hapMap: {description: "reference haplotype map for CrosscheckFingerprints"}
+        stratIntervals: {description: "intervals for stratifiction (can be picard interval_list or bed format)"}
+        stratLabels: {description: "labels by which to identify stratification intervals (must be same length as stratIntervals)"}
+        jexlVariantSelectors: {description: "variant types to select over (defined by jexl fed to GATK SelectVariants)"}
+        variantSelectorLabels: {description: "labels by which to identify variant selectors (must be same length as jexlVariantSelectors)"}
+        doIndelLengthStratification: {description: "whether or not to perform stratification by indel length"}
+        requireMatchingGenotypes: {description: "whether to require genotypes to match in order to be a true positive"}
+        truthIsSitesOnlyVcf: {description: "whether the truth VCF is a sites-only VCF file without any sample information"}
+        gatkTag: {description: "version of gatk docker to use.  Defaults to 4.0.11.0"}
+        analysisRegion: {description: "if provided (gatk format, single interval e.g., 'chr20', or 'chr20:1-10') all the analysis will be performed only within the region."}
+        passingOnly: {description:"Have vcfEval only consider the passing variants"}
+        vcfScoreField: {description:"Have vcfEval use this field for making the roc-plot. If this is an info field (like VSQLOD) it should be provided as INFO.VQSLOD, otherewise it is assumed to be a format field."}
+        gatkJarForAnnotation: {description:"GATK jar that can calculate necessary annotations for jexl Selections when using VCFEval."}
+        annotationNames: {description:"Annotation arguments to GATK (-A argument, multiple OK)"}
+        dummyInputForTerraCallCaching: {description:"When running on Terra, use workspace.name as this input to ensure that all tasks will only cache hit to runs in your own workspace. This will prevent call caching from failing with 'Cache Miss (10 failed copy attempts)'. Outside of Terra this can be left empty. This dummy input is only needed for tasks that have no inputs specific to the sample being run (such as CreateIntervalList which does not take in any sample data)."}
+    }
+
+    input{
+
+        File evalVcf
+        String evalLabel
+        File evalVcfIndex
+        File? evalBam
+        String? evalBamLabel
+
+        File truthVcf
+        String truthLabel
+        File truthVcfIndex
+        File? truthBam
+        String? truthBamLabel
+
+        File confidenceInterval
+
+        File ref_map_file
+
+        String? analysisRegion
+        File? hapMap
+
+        Array[File] stratIntervals = []
+        Array[String] stratLabels = []
+        Array[String]? jexlVariantSelectors
+        Array[String]? variantSelectorLabels
+
+        Int? threadsVcfEval = 2
+        Boolean doIndelLengthStratification = true
+        # Small-genome variant: default to preemptible VMs (idempotent eval tasks).
+        Int? preemptible = 3
+        String gatkTag="4.0.11.0"
+        Boolean requireMatchingGenotypes = true
+        Boolean truthIsSitesOnlyVcf = false
+        File? gatkJarForAnnotation
+        Array[String]? annotationNames
+        Boolean enableRefOverlap = false
+        Boolean passingOnly = true
+        String? vcfScoreField
+        String? dummyInputForTerraCallCaching
+    }
+
+    # Get ref info:
+    Map[String, String] ref_map = read_map(ref_map_file)
+
+    if (defined(analysisRegion)) {
+        call CreateIntervalList {
+            input:
+                reference = ref_map["fasta"],
+                reference_index = ref_map["fai"],
+                reference_dict = ref_map["dict"],
+                interval_string = select_first([analysisRegion]),
+                gatkTag = gatkTag,
+                dummyInputForTerraCallCaching = dummyInputForTerraCallCaching
+        }
+    }
+
+    Array[File] actualStratIntervals = flatten([[""], stratIntervals])
+    Array[String] actualStratLabels = flatten([[""], stratLabels])
+    Array[String] actualSelectorLabels = select_first([variantSelectorLabels,[""]])
+    Array[String] actualSelectorJEXL = select_first([jexlVariantSelectors,[""]])
+
+    #check that lengths of different arrays are compatible
+    if (length(actualStratLabels)!= length(actualStratIntervals)) {
+         call ErrorWithMessage as Error6 {
+             input:
+                 message="Stratification vcf list is length "+length(actualStratIntervals)+" while stratification labels list is length "+length(actualStratLabels)
+         }
+    }
+
+    if (length(actualSelectorLabels) != length(actualSelectorJEXL)) {
+        call ErrorWithMessage as Error7 {
+            input:
+                message="Variant selector list is length "+length(actualSelectorJEXL)+" while labels list is "+length(actualSelectorLabels)
+        }
+    }
+
+    if (defined(hapMap)) {
+        call MatchEvalTruth as Match {
+            input:
+                evalVcf = evalVcf,
+                truthVcf = truthVcf,
+                evalVcfIndex = evalVcfIndex,
+                truthVcfIndex = truthVcfIndex,
+                hapMap = select_first([hapMap]),
+                gatkTag = gatkTag,
+                preemptible = preemptible
+        }
+    }
+    Array[String] indelLabels=["deletion","insertion","indel_fine_m20","indel_fine_m19","indel_fine_m18","indel_fine_m17","indel_fine_m16","indel_fine_m15",
+                               "indel_fine_m14","indel_fine_m13","indel_fine_m12","indel_fine_m11","indel_fine_m10","indel_fine_m9","indel_fine_m8","indel_fine_m7",
+                               "indel_fine_m6","indel_fine_m5","indel_fine_m4","indel_fine_m3","indel_fine_m2","indel_fine_m1","indel_fine_1","indel_fine_2","indel_fine_3",
+                               "indel_fine_4","indel_fine_5","indel_fine_6","indel_fine_7","indel_fine_8","indel_fine_9","indel_fine_10","indel_fine_11","indel_fine_12",
+                               "indel_fine_13","indel_fine_14","indel_fine_15","indel_fine_16","indel_fine_17","indel_fine_18","indel_fine_19","indel_fine_20","indel_coarse_m30.0",
+                               "indel_coarse_m25.0","indel_coarse_m20.0","indel_coarse_m15.0","indel_coarse_m10.0","indel_coarse_m5.0","indel_coarse_0.0","indel_coarse_5.0",
+                               "indel_coarse_10.0","indel_coarse_15.0","indel_coarse_20.0","indel_coarse_25.0","indel_coarse_30.0"]
+
+    Array[String] indelJexl=["vc.isSimpleIndel()  && vc.getIndelLengths().0<0","vc.isSimpleIndel()  && vc.getIndelLengths().0>0","vc.isSimpleIndel()  && vc.getIndelLengths().0==-20",
+                             "vc.isSimpleIndel()  && vc.getIndelLengths().0==-19","vc.isSimpleIndel()  && vc.getIndelLengths().0==-18","vc.isSimpleIndel()  && vc.getIndelLengths().0==-17",
+                             "vc.isSimpleIndel()  && vc.getIndelLengths().0==-16","vc.isSimpleIndel()  && vc.getIndelLengths().0==-15","vc.isSimpleIndel()  && vc.getIndelLengths().0==-14",
+                             "vc.isSimpleIndel()  && vc.getIndelLengths().0==-13","vc.isSimpleIndel()  && vc.getIndelLengths().0==-12","vc.isSimpleIndel()  && vc.getIndelLengths().0==-11",
+                             "vc.isSimpleIndel()  && vc.getIndelLengths().0==-10","vc.isSimpleIndel()  && vc.getIndelLengths().0==-9","vc.isSimpleIndel()  && vc.getIndelLengths().0==-8",
+                             "vc.isSimpleIndel()  && vc.getIndelLengths().0==-7","vc.isSimpleIndel()  && vc.getIndelLengths().0==-6","vc.isSimpleIndel()  && vc.getIndelLengths().0==-5",
+                             "vc.isSimpleIndel()  && vc.getIndelLengths().0==-4","vc.isSimpleIndel()  && vc.getIndelLengths().0==-3","vc.isSimpleIndel()  && vc.getIndelLengths().0==-2",
+                             "vc.isSimpleIndel()  && vc.getIndelLengths().0==-1","vc.isSimpleIndel()  && vc.getIndelLengths().0==1","vc.isSimpleIndel()  && vc.getIndelLengths().0==2",
+                             "vc.isSimpleIndel()  && vc.getIndelLengths().0==3","vc.isSimpleIndel()  && vc.getIndelLengths().0==4","vc.isSimpleIndel()  && vc.getIndelLengths().0==5",
+                             "vc.isSimpleIndel()  && vc.getIndelLengths().0==6","vc.isSimpleIndel()  && vc.getIndelLengths().0==7","vc.isSimpleIndel()  && vc.getIndelLengths().0==8",
+                             "vc.isSimpleIndel()  && vc.getIndelLengths().0==9","vc.isSimpleIndel()  && vc.getIndelLengths().0==10","vc.isSimpleIndel()  && vc.getIndelLengths().0==11",
+                             "vc.isSimpleIndel()  && vc.getIndelLengths().0==12","vc.isSimpleIndel()  && vc.getIndelLengths().0==13","vc.isSimpleIndel()  && vc.getIndelLengths().0==14",
+                             "vc.isSimpleIndel()  && vc.getIndelLengths().0==15","vc.isSimpleIndel()  && vc.getIndelLengths().0==16","vc.isSimpleIndel()  && vc.getIndelLengths().0==17",
+                             "vc.isSimpleIndel()  && vc.getIndelLengths().0==18","vc.isSimpleIndel()  && vc.getIndelLengths().0==19","vc.isSimpleIndel()  && vc.getIndelLengths().0==20",
+                             "vc.isSimpleIndel()  && vc.getIndelLengths().0<-27.5 && vc.getIndelLengths().0>-32.5","vc.isSimpleIndel()  && vc.getIndelLengths().0<-22.5 && vc.getIndelLengths().0>-27.5",
+                             "vc.isSimpleIndel()  && vc.getIndelLengths().0<-17.5 && vc.getIndelLengths().0>-22.5","vc.isSimpleIndel()  && vc.getIndelLengths().0<-12.5 && vc.getIndelLengths().0>-17.5",
+                             "vc.isSimpleIndel()  && vc.getIndelLengths().0<-7.5 && vc.getIndelLengths().0>-12.5","vc.isSimpleIndel()  && vc.getIndelLengths().0<-2.5 && vc.getIndelLengths().0>-7.5",
+                             "vc.isSimpleIndel()  && vc.getIndelLengths().0<2.5 && vc.getIndelLengths().0>-2.5","vc.isSimpleIndel()  && vc.getIndelLengths().0<7.5 && vc.getIndelLengths().0>2.5",
+                             "vc.isSimpleIndel()  && vc.getIndelLengths().0<12.5 && vc.getIndelLengths().0>7.5","vc.isSimpleIndel()  && vc.getIndelLengths().0<17.5 && vc.getIndelLengths().0>12.5",
+                             "vc.isSimpleIndel()  && vc.getIndelLengths().0<22.5 && vc.getIndelLengths().0>17.5","vc.isSimpleIndel()  && vc.getIndelLengths().0<27.5 && vc.getIndelLengths().0>22.5",
+                             "vc.isSimpleIndel()  && vc.getIndelLengths().0<32.5 && vc.getIndelLengths().0>27.5"]
+
+    # (Small variant) The 55 indel-length bins are consumed directly by
+    # EvalIndelLengthAllBins below, so the per-bin VariantSelector scatter that
+    # the standard workflow builds here is intentionally omitted.
+
+    if (defined(jexlVariantSelectors)) {
+        scatter (select in zip(actualSelectorLabels,actualSelectorJEXL)) {
+            VariantSelector variantSelectors = object{ jexl: select.right,
+                                                label : select.left
+                                                }
+        }
+    }
+
+    Array[VariantSelector] defaultVS = [object{ jexl: "vc.isIndel() && vc.getHetCount() == 1", label: "HetIndel" },
+                                        object{jexl: "vc.isIndel() && vc.getHomVarCount() == 1", label: "HomVarIndel"},
+                                        object{jexl: "vc.isSNP() && vc.getHetCount() == 1", label: "HetSNP"},
+                                        object{jexl: "vc.isSNP() && vc.getHomVarCount() == 1", label: "HomVarSNP"}]
+    Array[VariantSelector] actualVariantSelectors = flatten(select_all([defaultVS,variantSelectors]))
+
+    if (defined(stratIntervals)) {
+        scatter (actStratIL in actualStratIntervals) {
+
+            # Required because of `miniwdl check`:
+            String string_conversion_of_actStratIL = actStratIL
+
+            if(string_conversion_of_actStratIL != "") {
+                call ConvertIntervals as StratConvertIntervals {
+                    input:
+                        inputIntervals = actStratIL,
+                        refDict = ref_map["dict"],
+                        gatkTag = gatkTag,
+                        subset_interval = CreateIntervalList.interval_list,
+                        preemptible = preemptible,
+                        dummyInputForTerraCallCaching = dummyInputForTerraCallCaching
+
+                }
+            }
+        }
+    }
+    Array[File] stratBeds = select_all(flatten(select_all([[""],StratConvertIntervals.bed])))
+    Array[File] stratILs = select_all(flatten(select_all([[""],StratConvertIntervals.intervalList])))
+
+    scatter (strat in zip(zip(stratILs,stratBeds),actualStratLabels)) {
+        Stratifier stratifiers = object {intervalList : strat.left.left,
+                                    bed : strat.left.right,
+                                    label : strat.right
+                                    }
+    }
+
+    call ConvertIntervals as ConfidenceConvertIntervals {
+        input:
+            inputIntervals = confidenceInterval,
+            refDict = ref_map["dict"],
+            gatkTag = gatkTag,
+            preemptible = preemptible,
+            subset_interval = CreateIntervalList.interval_list,
+            dummyInputForTerraCallCaching = dummyInputForTerraCallCaching
+    }
+
+    scatter (stratifier in stratifiers) {
+
+        # Required because of `miniwdl check`
+        String tmp_strat_interval_list = select_first([stratifier.intervalList])
+
+        if (stratifier.label != "" && tmp_strat_interval_list != "") {
+            String stratLabel = select_first([stratifier.label,""])
+            File stratIL = select_first([stratifier.intervalList,""])
+            File stratBed = select_first([stratifier.bed,""])
+            String outputPreStrat = evalLabel+"_"+truthLabel+"_"+stratLabel
+        }
+        String outputPrefix = select_first([outputPreStrat,evalLabel+"_"+truthLabel])
+
+        call CheckForVariants as CheckForVariantsEval {
+            input:
+                vcf = evalVcf,
+                vcfIndex = evalVcfIndex,
+                confidenceIL = ConfidenceConvertIntervals.intervalList,
+                stratIL = stratIL,
+                gatkTag = gatkTag,
+                preemptible = preemptible
+        }
+
+        call CheckForVariants as CheckForVariantsTruth {
+            input:
+                vcf = truthVcf,
+                vcfIndex = truthVcfIndex,
+                confidenceIL = ConfidenceConvertIntervals.intervalList,
+                stratIL = stratIL,
+                gatkTag = gatkTag,
+                preemptible = preemptible
+        }
+
+        if (CheckForVariantsTruth.variantsFound && CheckForVariantsEval.variantsFound) {
+            call VcfEval as StandardVcfEval {
+                input:
+                    truthVCF = truthVcf,
+                    truthVCFIndex = truthVcfIndex,
+                    evalVCF = evalVcf,
+                    evalVCFIndex = evalVcfIndex,
+                    confidenceBed = ConfidenceConvertIntervals.bed,
+                    stratBed = stratBed,
+                    ref = ref_map["fasta"],
+                    refDict = ref_map["dict"],
+                    refIndex = ref_map["fai"],
+                    outputPre = outputPrefix+"_vcfeval",
+                    threads = threadsVcfEval,
+                    preemptible = preemptible,
+                    requireMatchingGenotypes = requireMatchingGenotypes,
+                    truthIsSitesOnlyVcf = truthIsSitesOnlyVcf,
+                    passingOnly = passingOnly,
+                    vcfScoreField = vcfScoreField,
+                    enableRefOverlap = enableRefOverlap
+            }
+
+            call WriteXMLfile as VcfEvalWriteXMLfile {
+                input:
+                    input_files = flatten([select_all([StandardVcfEval.outVcf,ConfidenceConvertIntervals.bed,stratifier.bed]), select_all([evalBam, truthBam])]),
+                    input_names = flatten([select_all([outputPrefix+"_vcfeval","confidence_intervals",stratifier.label]), select_all([evalBamLabel, truthBamLabel])]),
+                    reference_version = ref_map["fasta"],
+                    file_name = outputPrefix+"_vcfeval",
+                    preemptible = preemptible
+            }
+
+            call CountUNKVcfEval {
+                input:
+                    vcf = StandardVcfEval.outVcf,
+                    vcfIndex = StandardVcfEval.outVcfIndex,
+                    gatkTag = gatkTag,
+                    preemptible = preemptible
+            }
+        }
+
+        String areVariants = if(CheckForVariantsTruth.variantsFound && CheckForVariantsEval.variantsFound) then "yes" else "no"
+        call SummariseVcfEval {
+            input:
+                evalLabel = evalLabel,
+                truthLabel = truthLabel,
+                stratLabel = stratLabel,
+                summaryFile = StandardVcfEval.outSummary,
+                igvSession = VcfEvalWriteXMLfile.igv_session,
+                areVariants = areVariants,
+                unkSNP = CountUNKVcfEval.UNK_SNP,
+                unkINDEL = CountUNKVcfEval.UNK_INDEL,
+                preemptible = preemptible
+        }
+    }
+
+    scatter ( i in range(length(stratifiers)) ) {
+        AnnotatedVcfs annotatedVcfsList = object{vcfVcfEval : StandardVcfEval.outVcf[i],
+                                            vcfVcfEvalIndex : StandardVcfEval.outVcfIndex[i],
+                                            stratLabel : stratifiers[i].label,
+                                            evalLabel : evalLabel,
+                                            truthLabel : truthLabel,
+                                            stratBed : stratBed[i],
+                                            confidenceBed : ConfidenceConvertIntervals.bed,
+                                            namePrefix : outputPrefix[i]
+                                            }
+    }
+
+
+    # Small-genome variant: instead of fanning the 55 indel-length bins into
+    # 55 x (Eval + WriteXML + Summarise) tasks per eval-combo (which dominates
+    # cost via VM startup/RAM-hours), loop all bins inside a single right-sized
+    # task per eval-combo. One VM does what ~165 VMs did.
+    scatter (annotatedVcfs in annotatedVcfsList) {
+        if (defined(annotatedVcfs.vcfVcfEval) && defined(annotatedVcfs.vcfVcfEvalIndex) && doIndelLengthStratification) {
+            call EvalIndelLengthAllBins {
+                input:
+                    vcf = annotatedVcfs.vcfVcfEval,
+                    vcfIndex = annotatedVcfs.vcfVcfEvalIndex,
+                    indelLabels = indelLabels,
+                    indelJexl = indelJexl,
+                    selectTPCall="CALL == 'TP'",
+                    selectTPBase="BASE == 'TP'",
+                    selectFN="(BASE == 'FN' || BASE == 'FN_CA')",
+                    selectFP="(CALL == 'FP' || CALL == 'FP_CA')",
+                    sampleCall="CALLS",
+                    sampleBase="BASELINE",
+                    engine="VcfEval",
+                    evalLabel = annotatedVcfs.evalLabel,
+                    truthLabel = annotatedVcfs.truthLabel,
+                    stratLabel = annotatedVcfs.stratLabel,
+                    gatkTag = gatkTag,
+                    gatkJarForAnnotation = gatkJarForAnnotation,
+                    annotationNames = annotationNames,
+                    reference = ref_map["fasta"],
+                    refDict = ref_map["dict"],
+                    refIndex = ref_map["fai"],
+                    preemptible = preemptible
+            }
+        }
+    }
+
+
+
+
+    scatter (selectorCombo in cross(annotatedVcfsList,actualVariantSelectors)) {
+       EvalStratSelectorCombo evalStratSelectorCombos = object{annotatedVcfs : selectorCombo.left,
+                                                    variantSelector : selectorCombo.right
+                                                    }
+    }
+    scatter (evalStratSelectorCombo in evalStratSelectorCombos) {
+                if (defined(evalStratSelectorCombo.annotatedVcfs.vcfVcfEval) && defined(evalStratSelectorCombo.annotatedVcfs.vcfVcfEvalIndex)) {
+                    call EvalForVariantSelection as EvalSelectorVcfEval {
+                        input:
+                            vcf = evalStratSelectorCombo.annotatedVcfs.vcfVcfEval,
+                            vcfIndex = evalStratSelectorCombo.annotatedVcfs.vcfVcfEvalIndex,
+                            jexl = evalStratSelectorCombo.variantSelector.jexl,
+                            engine="VcfEval",
+                            selectTPCall="CALL == 'TP'",
+                            selectTPBase="BASE == 'TP'",
+                            selectFN="(BASE == 'FN' || BASE == 'FN_CA')",
+                            selectFP="(CALL == 'FP' || CALL == 'FP_CA')",
+                            sampleCall="CALLS",
+                            sampleBase="BASELINE",
+                            gatkTag = gatkTag,
+                            preemptible = preemptible,
+                            gatkJarForAnnotation = gatkJarForAnnotation,
+                            annotationNames = annotationNames,
+                            reference = ref_map["fasta"],
+                            refDict = ref_map["dict"],
+                            refIndex = ref_map["fai"]
+                    }
+                    call WriteXMLfile as VcfEvalSelectorWriteXMLfile {
+                                input:
+                                    input_files = flatten([select_all([EvalSelectorVcfEval.selectedTPCall,EvalSelectorVcfEval.selectedTPBase,EvalSelectorVcfEval.selectedFP,EvalSelectorVcfEval.selectedFN,
+                                        evalStratSelectorCombo.annotatedVcfs.vcfVcfEval,evalStratSelectorCombo.annotatedVcfs.confidenceBed,evalStratSelectorCombo.annotatedVcfs.stratBed]), select_all([evalBam, truthBam])]),
+                                    input_names = flatten([select_all(["TP_Eval","TP_Base","FP","FN","All_Variants","confidence_intervals",evalStratSelectorCombo.annotatedVcfs.stratLabel]), select_all([evalBamLabel, truthBamLabel])]),
+                                    reference_version = ref_map["fasta"],
+                                    file_name = evalStratSelectorCombo.annotatedVcfs.namePrefix+"_"+evalStratSelectorCombo.variantSelector.label+"_vcfeval",
+                                    preemptible = preemptible
+                    }
+
+                    call SummariseForVariantSelection as VcfEvalSummariseForVariantSelection {
+                                input:
+                                    evalLabel = evalStratSelectorCombo.annotatedVcfs.evalLabel,
+                                    truthLabel = evalStratSelectorCombo.annotatedVcfs.truthLabel,
+                                    stratLabel = evalStratSelectorCombo.annotatedVcfs.stratLabel,
+                                    variantLabel = evalStratSelectorCombo.variantSelector.label,
+                                    engine="VcfEval",
+                                    igvSession = VcfEvalSelectorWriteXMLfile.igv_session,
+                                    TP_CALL = EvalSelectorVcfEval.TP_CALL,
+                                    TP_BASE = EvalSelectorVcfEval.TP_BASE,
+                                    FP = EvalSelectorVcfEval.FP,
+                                    FN = EvalSelectorVcfEval.FN,
+                                    preemptible = preemptible
+                    }
+                }
+    }
+
+    Array[File] summaries = flatten([SummariseVcfEval.summaryOut,select_all(VcfEvalSummariseForVariantSelection.summaryOut),
+                                    select_all(EvalIndelLengthAllBins.summaryOut)])
+
+    call CombineSummaries {
+        input:
+            summaries = summaries,
+            preemptible = preemptible
+    }
+
+    ################################################################################
+
+    output {
+        File summary = CombineSummaries.summaryOut
+        Float snpPrecision = SummariseVcfEval.snpPrecision[0]
+        Float indelPrecision = SummariseVcfEval.indelPrecision[0]
+        Float snpRecall = SummariseVcfEval.snpRecall[0]
+        Float indelRecall = SummariseVcfEval.indelRecall[0]
+        Float snpF1Score = SummariseVcfEval.snpF1Score[0]
+        Float indelF1Score = SummariseVcfEval.indelF1Score[0]
+        Array[File?] snpRocs = StandardVcfEval.outSnpRoc
+        Array[File?] nonSnpRocs = StandardVcfEval.outNonSnpRoc
+    }
+}
+
+################################################################################
+################################################################################
+################################################################################
+
+struct EvalTruthMatch {
+        File truthVcf
+        File truthVcfIndex
+        File confidenceIntervals
+        String truthLabel
+        File evalVcf
+        File evalVcfIndex
+        String evalLabel
+}
+
+struct VariantSelector {
+    String jexl
+    String label
+}
+
+struct Stratifier {
+    File? intervalList
+    File? bed
+    String? label
+}
+
+struct EvalStratCombo {
+    EvalTruthMatch evalTruthMatch
+    Stratifier stratifier
+}
+
+struct AnnotatedVcfs {
+    File? vcfVcfEval
+    File? vcfVcfEvalIndex
+    String? stratLabel
+    String evalLabel
+    String truthLabel
+    File? stratBed
+    File? confidenceBed
+    String namePrefix
+}
+struct EvalStratSelectorCombo {
+    AnnotatedVcfs annotatedVcfs
+    VariantSelector variantSelector
+}
+
+#Check to see if there are variants in the given vcf which overlap the confidence and stratification intervals
+task CheckForVariants {
+    input{
+        File vcf
+        File vcfIndex
+        File confidenceIL
+        File? stratIL
+        Int? preemptible
+        Int? memoryMaybe
+        String gatkTag
+        }
+        Int memoryDefault = 16
+        Int memoryJava = select_first([memoryMaybe,memoryDefault])
+        Int memoryRam = memoryJava+2
+
+        Int disk_size = 10 + ceil(size(vcf, "GB") + size(vcfIndex, "GB") + size(confidenceIL, "GB") + size(stratIL, "GB"))
+
+    command <<<
+        set -xeuo pipefail
+
+    # GATK needs the index as a sibling of the VCF, but Cromwell may localize the
+    # VCF and its index into different directories. Ensure the index sits next to
+    # the VCF as <vcf>.tbi before running.
+    IDX="$(dirname "~{vcf}")/$(basename "~{vcf}").tbi"
+    if [ ! -e "${IDX}" ]; then ln -s "~{vcfIndex}" "${IDX}"; fi
+
+    nVariants="$(gatk --java-options "-Xmx~{memoryJava}G" CountVariants -V ~{vcf} -L ~{confidenceIL} ~{"-L " + stratIL} -isr INTERSECTION | tail -1)"
+    if [ "$nVariants" -gt "0" ]; then echo "true" > outBool.txt; else echo "false" > outBool.txt; fi
+    >>>
+
+    runtime {
+            docker: "us.gcr.io/broad-gatk/gatk:"+gatkTag
+            preemptible: select_first([preemptible,0])
+            disks: "local-disk " + disk_size + " HDD"
+            bootDiskSizeGb: 16
+            memory: memoryRam + " GB"
+    }
+
+    output {
+        Boolean variantsFound = read_boolean("outBool.txt")
+    }
+}
+
+#Evaluate evalVCF against truthVCF using vcfeval
+task VcfEval {
+    input{
+        File truthVCF
+        File truthVCFIndex
+
+        File evalVCF
+        File evalVCFIndex
+
+        File confidenceBed
+
+        File? stratBed
+
+        File ref
+        File refDict
+        File refIndex
+
+        String outputPre
+        Boolean passingOnly
+
+        String? vcfScoreField
+        Int? preemptible
+        String? memUser
+        Int? threads
+
+        Boolean requireMatchingGenotypes
+        Boolean truthIsSitesOnlyVcf
+        Boolean enableRefOverlap = false
+    }
+    String memDefault="16 GB"
+    String mem = select_first([memUser,memDefault])
+
+    Int cpu = select_first([threads,1])
+    Int disk_size = 50 + ceil(size(truthVCF, "GB") + size(truthVCFIndex, "GB") + 2.2 * size(evalVCF, "GB") + size(evalVCFIndex, "GB") + size(confidenceBed, "GB") + size(stratBed, "GB") + size(ref, "GB") + size(refDict, "GB") + size(refIndex, "GB"))
+
+    command <<<
+    set -xeuo pipefail
+
+    /bin/rtg-tools/rtg format -o rtg_ref ~{ref}
+    /bin/rtg-tools/rtg vcfeval \
+        ~{false="--all-records" true="" passingOnly} \
+        ~{"--vcf-score-field=" + vcfScoreField} \
+        ~{false="--squash-ploidy" true="" requireMatchingGenotypes} \
+        ~{false="" true="--sample ALT" truthIsSitesOnlyVcf} \
+        ~{true="--ref-overlap" false="" enableRefOverlap} \
+        -b ~{truthVCF} -c ~{evalVCF} \
+        -e ~{confidenceBed} ~{"--bed-regions " + stratBed} \
+        ~{false="--output-mode combine" true="" truthIsSitesOnlyVcf} \
+        --decompose -t rtg_ref \
+        ~{"--threads "+threads} -o output_dir
+
+    for f in output_dir/*; do
+        mv $f ~{outputPre}_"$(basename "$f")";
+    done
+
+    /bin/rtg-tools/rtg rocplot --precision-sensitivity --title="~{outputPre} SNP"   --svg=~{outputPre}.snp.svg   ~{outputPre}_snp_roc.tsv.gz
+    /bin/rtg-tools/rtg rocplot --precision-sensitivity --title="~{outputPre} INDEL" --svg=~{outputPre}.indel.svg ~{outputPre}_non_snp_roc.tsv.gz
+
+    python3 -<<"EOF" ~{outputPre}_snp_roc.tsv.gz ~{outputPre}_non_snp_roc.tsv.gz ~{outputPre}_summary.csv
+    import gzip
+    import sys
+
+    indel_sensitivity = 0
+    indel_precision = 0
+    indel_fscore = 0
+    indel_TP_Base = 0
+    indel_TP_Eval = 0
+    indel_FP = 0
+    indel_FN = 0
+
+    snp_sensitivity = 0
+    snp_precision = 0
+    snp_fscore = 0
+    snp_TP_Base = 0
+    snp_TP_Eval = 0
+    snp_FP = 0
+    snp_FN = 0
+
+    with gzip.open(sys.argv[1],"rt") as f_snp:
+        for line in f_snp:
+            try:
+                snp_sensitivity = float(line.split()[6])
+                snp_precision = float(line.split()[5])
+                snp_fscore = float(line.split()[7])
+                snp_TP_Eval = float(line.split()[3])
+                snp_TP_Base = float(line.split()[1])
+                snp_FP = float(line.split()[2])
+                snp_FN = float(line.split()[4])
+            except ValueError:
+                continue
+            except IndexError:
+                continue
+        f_snp.close()
+    with gzip.open(sys.argv[2],"rt") as f_indel:
+        for line in f_indel:
+            try:
+                indel_sensitivity = float(line.split()[6])
+                indel_precision = float(line.split()[5])
+                indel_fscore = float(line.split()[7])
+                indel_TP_Eval = float(line.split()[3])
+                indel_TP_Base = float(line.split()[1])
+                indel_FP = float(line.split()[2])
+                indel_FN = float(line.split()[4])
+            except ValueError:
+                continue
+            except IndexError:
+                continue
+        f_indel.close()
+
+    str_indel_sensitivity = str(indel_sensitivity)
+    str_indel_precision = str(indel_precision)
+    str_indel_fscore = str(indel_fscore)
+    str_snp_sensitivity = str(snp_sensitivity)
+    str_snp_precision = str(snp_precision)
+    str_snp_fscore = str(snp_fscore)
+
+
+    if indel_TP_Eval+indel_FP==0:
+        str_indel_precision="NA"
+    if indel_TP_Base+indel_FN==0:
+        str_indel_sensitivity="NA"
+    if str_indel_sensitivity=="NA" or str_indel_precision=="NA":
+        str_indel_fscore="NA"
+
+    if snp_TP_Eval+snp_FP==0:
+        str_snp_precision="NA"
+    if snp_TP_Base+snp_FN==0:
+        str_snp_sensitivity="NA"
+    if str_snp_sensitivity=="NA" or str_snp_precision=="NA":
+        str_snp_fscore="NA"
+
+
+
+    with open(sys.argv[3],"wt") as f_out:
+        f_out.write(",".join(["Type","Precision","Recall","F1_Score","TP_Eval","TP_Base","FP","FN"])+"\n")
+        f_out.write(",".join(["SNP",str_snp_precision,str_snp_sensitivity,str_snp_fscore,str(snp_TP_Eval),str(snp_TP_Base),str(snp_FP),str(snp_FN)])+"\n")
+        f_out.write(",".join(["INDEL",str_indel_precision,str_indel_sensitivity,str_indel_fscore,str(indel_TP_Eval),str(indel_TP_Base),str(indel_FP),str(indel_FN)])+"\n")
+        f_out.close()
+    EOF
+    >>>
+
+    runtime {
+        docker: "ckachulis/rtg-tools:0.1"
+        preemptible: select_first([preemptible,0])
+        memory: mem
+        cpu: cpu
+        disks: "local-disk " + disk_size + " HDD"
+    }
+
+    output {
+        Array[File] outs = glob("${outputPre}_*")
+        File outSummary="${outputPre}_summary.csv"
+        File outVcf="${outputPre}_output.vcf.gz"
+        File outVcfIndex="${outputPre}_output.vcf.gz.tbi"
+        File outSnpRocPlot="~{outputPre}.snp.svg"
+        File outNonRocPlot="~{outputPre}.indel.svg"
+        File outSnpRoc="${outputPre}_snp_roc.tsv.gz"
+        File outNonSnpRoc="${outputPre}_non_snp_roc.tsv.gz"
+    }
+}
+
+#Evaluate evalVCF against truthVCF using hap.py
+task EvalHappy {
+    input{
+        File truthVCF
+        File truthVCFIndex
+        File evalVCF
+        File confidenceBed
+        File? stratBed
+        File ref
+        File refDict
+        File refIndex
+        String outputPre
+        String? memUser
+        Int? preemptible
+        Int? threads
+        String happyTag
+    }
+    String memDefault="16 GB"
+    String mem = select_first([memUser,memDefault])
+
+    Int cpu = select_first([threads,1])
+    Int disk_size = 10 + ceil(size(truthVCF, "GB") + size(truthVCFIndex, "GB") + 2.2 * size(evalVCF, "GB") + size(confidenceBed, "GB") + size(stratBed, "GB") + size(ref, "GB") + size(refDict, "GB") + size(refIndex, "GB"))
+
+
+    command <<<
+        /opt/hap.py/bin/hap.py ~{truthVCF} ~{evalVCF} -f ~{confidenceBed} -r ~{ref} -V ~{"-T " + stratBed} -L --preprocess-truth ~{"--threads "+threads} -o ~{outputPre}
+    >>>
+
+    runtime {
+        docker: "pkrusche/hap.py:"+happyTag
+        memory: mem
+        preemptible: select_first([preemptible,0])
+        cpu: cpu
+        disks: "local-disk " + disk_size + " HDD"
+    }
+
+    output {
+        Array[File] outs = glob("${outputPre}*")
+        File outSummary="${outputPre}.summary.csv"
+        File outVcf="${outputPre}.vcf.gz"
+        File outVcfIndex="${outputPre}.vcf.gz.tbi"
+    }
+}
+
+#Evaluate evalVCF against truthVCF using picard GenotypeConcordance
+task EvalGATKGC {
+    input{
+        File truthVCF
+        File truthVCFIndex
+        File evalVCF
+        File evalVCFIndex
+        File intervalList
+        File? stratIL
+        File ref
+        File refDict
+        File refIndex
+        String outputPre
+        Int? preemptible
+        Int? memoryMaybe
+        String gatkTag
+    }
+    Int memoryDefault = 16
+    Int memoryJava = select_first([memoryMaybe,memoryDefault])
+    Int memoryRam = memoryJava+2
+    Int disk_size = 10 + ceil(size(truthVCF, "GB") + size(truthVCFIndex, "GB") + 2.2 * size(evalVCF, "GB") + size(intervalList, "GB") + size(stratIL, "GB") + size(evalVCFIndex, "GB") + size(ref, "GB") + size(refDict, "GB") + size(refIndex, "GB"))
+
+
+    command <<<
+        gatk --java-options "-Xmx~{memoryJava}G" GenotypeConcordance -TV ~{truthVCF} -CV ~{evalVCF} -R ~{ref} -INTERVALS ~{intervalList} ~{"-INTERVALS " + stratIL} -USE_VCF_INDEX -OUTPUT_VCF -O ~{outputPre}
+    >>>
+
+    runtime {
+        docker: "us.gcr.io/broad-gatk/gatk:"+gatkTag
+        preemptible: select_first([preemptible,0])
+        disks: "local-disk " + disk_size + " HDD"
+        bootDiskSizeGb: 16
+        memory: memoryRam + " GB"
+    }
+
+    output {
+        Array[File] out = glob("${outputPre}*")
+        File outSummary="${outputPre}.genotype_concordance_summary_metrics"
+        File outCounts="${outputPre}.genotype_concordance_contingency_metrics"
+        File outVcf="${outputPre}.genotype_concordance.vcf.gz"
+        File outVcfIndex="${outputPre}.genotype_concordance.vcf.gz.tbi"
+    }
+}
+
+#takes in either a .bed or .intervallist and returns both a .bed and .intervallist version of the input
+task ConvertIntervals {
+    input {
+        File inputIntervals
+        File? subset_interval
+        Int? preemptible
+        Int? memoryMaybe
+        File refDict
+        String gatkTag
+        String? dummyInputForTerraCallCaching
+    }
+
+    Int memoryDefault = 16
+    Int memoryJava = select_first([memoryMaybe,memoryDefault])
+    Int memoryRam = memoryJava+2
+    Int disk_size = 10 + ceil(3 * size(inputIntervals, "GB") + size(refDict, "GB"))
+
+    command <<<
+        set -xeuo pipefail
+
+        # convert bed to interval_list, or copy interval_list
+        if [[ ~{inputIntervals} == *.bed || ~{inputIntervals} == *.bed.gz ]]; then
+                gatk --java-options "-Xmx~{memoryJava}G" \
+                    BedToIntervalList \
+                    -I ~{inputIntervals} \
+                    -O initial_intervals.interval_list \
+                    -SD ~{refDict}
+        else
+            cp ~{inputIntervals} initial_intervals.interval_list
+        fi
+
+        # optionally intersect interval_list with subset_interval
+
+        if [ ! -z ~{subset_interval} ];  then
+            gatk --java-options "-Xmx~{memoryJava}G" \
+                IntervalListTools \
+                -I initial_intervals.interval_list \
+                -I ~{subset_interval} \
+                -ACTION INTERSECT \
+                -O intervals.interval_list
+        else
+            mv initial_intervals.interval_list intervals.interval_list
+        fi
+
+        # convert result to BED
+        gatk --java-options "-Xmx~{memoryJava}G" \
+            IntervalListToBed \
+            -I intervals.interval_list \
+            -O intervals.bed
+    >>>
+
+    runtime {
+        docker: "us.gcr.io/broad-gatk/gatk:"+gatkTag
+        preemptible: select_first([preemptible,0])
+        disks: "local-disk " + disk_size + " HDD"
+        bootDiskSizeGb: 16
+        memory: memoryRam + " GB"
+    }
+
+    output {
+        File bed="intervals.bed"
+        File intervalList="intervals.interval_list"
+    }
+}
+
+#For now, due to a bug, the ouput annotated VCF from hap.py has a hardcoded HG19 header, so the VCF header must be fixed to represent the correct reference.
+#Additionally, due to a separate bug, UpdateVCFSequenceDictionary crashes in this case when trying to index a bgzipped vcf.  So for now have to perform indexing in a separate command.
+task FixVcfHeader {
+    input {
+        File vcf
+        File vcfIndex
+        File ref
+        File refDict
+        File refIndex
+        Int? preemptible
+        Int? memoryMaybe
+        String gatkTag
+    }
+    Int memoryDefault = 16
+    Int memoryJava = select_first([memoryMaybe,memoryDefault])
+    Int memoryRam = memoryJava+2
+    Int disk_size = 10 + ceil(2.2 * size(vcf, "GB") + 2.2 * size(vcfIndex, "GB") + size(ref, "GB") + size(refDict, "GB") + size(refIndex, "GB"))
+
+    command <<<
+        set -xeuo pipefail
+
+        gatk --java-options "-Xmx~{memoryJava}G" UpdateVCFSequenceDictionary -V ~{vcf} -O fixed.vcf.gz --source-dictionary ~{refDict} --replace --create-output-variant-index false
+        gatk --java-options "-Xmx~{memoryJava}G" IndexFeatureFile -F fixed.vcf.gz
+    >>>
+
+    runtime {
+            docker: "us.gcr.io/broad-gatk/gatk:"+gatkTag
+            preemptible: select_first([preemptible,0])
+            disks: "local-disk " + disk_size + " HDD"
+            bootDiskSizeGb: 16
+            memory: memoryRam + " GB"
+    }
+
+    output {
+        File outVcf="fixed.vcf.gz"
+        File outVcfIndex="fixed.vcf.gz.tbi"
+    }
+
+}
+
+#Count number of variants which were outside confidence region based on vcfeval annotated vcf
+task CountUNKVcfEval {
+    input {
+        File? vcf=""
+        File? vcfIndex=""
+        Int? preemptible
+        Int? memoryMaybe
+        String gatkTag
+    }
+    Int memoryDefault = 16
+    Int memoryJava = select_first([memoryMaybe,memoryDefault])
+    Int memoryRam = memoryJava+2
+    Int disk_size = 10 + ceil(size(vcf, "GB") + size(vcfIndex, "GB"))
+
+    command <<<
+        set -xeuo pipefail
+
+        gatk --java-options "-Xmx~{memoryJava}G" SelectVariants -V ~{vcf} -O selected.unk.snp.vcf -select "(CALL == 'OUT')" --select-type-to-include SNP
+        gatk --java-options "-Xmx~{memoryJava}G" SelectVariants -V ~{vcf} -O selected.unk.indel.vcf -select "(CALL == 'OUT')" --select-type-to-include INDEL
+
+        UNK_SNP="$(gatk --java-options "-Xmx~{memoryJava}G" CountVariants -V selected.unk.snp.vcf | tail -1)"
+        UNK_INDEL="$(gatk --java-options "-Xmx~{memoryJava}G" CountVariants -V selected.unk.indel.vcf | tail -1)"
+
+        echo "$UNK_SNP" > unk_snp.txt
+        echo "$UNK_INDEL" > unk_indel.txt
+    >>>
+    runtime {
+                docker: "us.gcr.io/broad-gatk/gatk:"+gatkTag
+                preemptible: select_first([preemptible,0])
+                disks: "local-disk " + disk_size + " HDD"
+                bootDiskSizeGb: 16
+                memory: memoryRam + " GB"
+    }
+    output {
+        Int UNK_SNP = read_int("unk_snp.txt")
+        Int UNK_INDEL = read_int("unk_indel.txt")
+    }
+}
+
+#Count number of variants which were outside confidence region based on GenotypeConcordance annotated vcf
+task CountUNKGC {
+        input {
+            File? vcfAnnotated=""
+            File? vcfIndexAnnotated=""
+            File vcfOrig
+            File vcfIndexOrig
+            Int? preemptible
+            Int? memoryMaybe
+            File? stratIL
+            String gatkTag
+        }
+        Int memoryDefault = 16
+        Int memoryJava = select_first([memoryMaybe,memoryDefault])
+        Int memoryRam = memoryJava+2
+        Int disk_size = 10 + ceil(size(vcfAnnotated, "GB") + size(vcfIndexAnnotated, "GB") + 2 * size(vcfOrig, "GB") + size(vcfIndexOrig, "GB") + size(stratIL, "GB"))
+
+        command <<<
+                set -xeuo pipefail
+
+                gatk --java-options "-Xmx~{memoryJava}G" SelectVariants -V ~{vcfOrig} -O selected.unk.snp.vcf.gz ~{"-L "+stratIL} --select-type-to-include SNP --discordance ~{vcfAnnotated}
+                gatk --java-options "-Xmx~{memoryJava}G" SelectVariants -V ~{vcfOrig} -O selected.unk.indel.vcf.gz ~{"-L "+stratIL} --select-type-to-include INDEL --discordance ~{vcfAnnotated}
+
+                UNK_SNP="$(gatk --java-options "-Xmx~{memoryJava}G" CountVariants -V selected.unk.snp.vcf.gz | tail -1)"
+                UNK_INDEL="$(gatk --java-options "-Xmx~{memoryJava}G" CountVariants -V selected.unk.indel.vcf.gz | tail -1)"
+
+                echo "$UNK_SNP" > unk_snp.txt
+                echo "$UNK_INDEL" > unk_indel.txt
+            >>>
+
+
+        runtime {
+                    docker: "us.gcr.io/broad-gatk/gatk:"+gatkTag
+                    preemptible: select_first([preemptible,0])
+                    disks: "local-disk " + disk_size + " HDD"
+                    bootDiskSizeGb: 16
+                    memory: memoryRam + " GB"
+        }
+
+        output {
+            Int UNK_SNP = read_int("unk_snp.txt")
+            Int UNK_INDEL = read_int("unk_indel.txt")
+        }
+}
+
+#Count TP,FP,FN for a particular selection of variants given by jexl
+task EvalForVariantSelection {
+    input {
+        File? vcf=""
+        File? vcfIndex=""
+        String jexl
+        Int? preemptible
+        Int? memoryMaybe
+        String engine
+        String selectTPCall
+        String selectTPBase
+        String selectFN
+        String selectFP
+        String sampleCall
+        String sampleBase
+        String gatkTag
+
+        Array[String] annotationNames=[]
+        File? gatkJarForAnnotation
+        File reference
+        File refDict
+        File refIndex
+    }
+
+    Int memoryDefault = 2
+    Int memoryJava = select_first([memoryMaybe,memoryDefault])
+    Int memoryRam = memoryJava+2
+
+    String selectionTPCall = jexl + " && " + selectTPCall
+    String selectionTPBase = jexl + " && " + selectTPBase
+    String selectionFN = jexl + " && " + selectFN
+    String selectionFP = jexl + " && " + selectFP
+
+    Int disk_size = 10 + ceil(4.2 * size(vcf, "GB") + 2.2 * size(vcfIndex, "GB") + size(reference, "GB"))
+
+    command <<<
+        set -xeuo pipefail
+
+        VCF=~{vcf}
+        if [[ ! -z "~{gatkJarForAnnotation}" ]]; then
+            java -jar ~{gatkJarForAnnotation} VariantAnnotator -V ~{vcf} -O annotated.vcf.gz ~{true="-A" false="" length(annotationNames)>0} ~{sep=" -A " annotationNames} -R ~{reference}
+            VCF = annotated.vcf.gz
+        else
+            touch annotated.vcf.gz
+        fi
+
+        gatk --java-options "-Xmx~{memoryJava}G" SelectVariants -V $VCF -O selected.TP_CALL.vcf.gz -select "~{selectionTPCall}" -sn ~{sampleCall}
+        gatk --java-options "-Xmx~{memoryJava}G" SelectVariants -V $VCF -O selected.TP_BASE.vcf.gz -select "~{selectionTPBase}" -sn ~{sampleBase}
+        gatk --java-options "-Xmx~{memoryJava}G" SelectVariants -V $VCF -O selected.FN.vcf.gz -select "~{selectionFN}" -sn ~{sampleBase}
+        gatk --java-options "-Xmx~{memoryJava}G" SelectVariants -V $VCF -O selected.FP.vcf.gz -select "~{selectionFP}" -sn ~{sampleCall}
+
+        TP_CALL="$(gatk --java-options "-Xmx~{memoryJava}G" CountVariants -V selected.TP_CALL.vcf.gz | tail -1)"
+        TP_BASE="$(gatk --java-options "-Xmx~{memoryJava}G" CountVariants -V selected.TP_BASE.vcf.gz | tail -1)"
+        FN="$(gatk --java-options "-Xmx~{memoryJava}G" CountVariants -V selected.FN.vcf.gz | tail -1)"
+        FP="$(gatk --java-options "-Xmx~{memoryJava}G" CountVariants -V selected.FP.vcf.gz | tail -1)"
+
+        echo "$TP_CALL" > tp_call.txt
+        echo "$TP_BASE" > tp_base.txt
+        echo "$FN" > fn.txt
+        echo "$FP" > fp.txt
+    >>>
+
+    runtime {
+            docker: "us.gcr.io/broad-gatk/gatk:"+gatkTag
+            preemptible: select_first([preemptible,0])
+            disks: "local-disk " + disk_size + " HDD"
+            bootDiskSizeGb: 16
+            memory: memoryRam + " GB"
+    }
+
+    output {
+        Int TP_CALL = read_int("tp_call.txt")
+        Int TP_BASE = read_int("tp_base.txt")
+        Int FP = read_int("fp.txt")
+        Int FN = read_int("fn.txt")
+        File selectedTPCall="selected.TP_CALL.vcf.gz"
+        File selectedTPBase="selected.TP_BASE.vcf.gz"
+        File selectedFP="selected.FP.vcf.gz"
+        File selectedFN="selected.FN.vcf.gz"
+
+        File annotated="annotated.vcf.gz"
+        File selectedTPCallIndex="selected.TP_CALL.vcf.gz.tbi"
+        File selectedTPBaseIndex="selected.TP_BASE.vcf.gz.tbi"
+        File selectedFPIndex="selected.FP.vcf.gz.tbi"
+        File selectedFNIndex="selected.FN.vcf.gz.tbi"
+    }
+
+}
+
+#create csv file of statistics based on TP,FP,FN
+task EvalIndelLengthAllBins {
+    meta {
+        description: "Small-genome replacement for the 55-way indel-length scatter: loops every indel-length bin inside one right-sized VM (GATK SelectVariants + CountVariants per bin), then emits a single combined summary CSV matching SummariseForIndelSelection's schema. Replaces ~165 tiny VMs with one."
+    }
+
+    parameter_meta {
+        vcf: "The vcfeval-annotated eval VCF (carries CALL/BASE annotations)."
+        indelLabels: "Per-bin labels, positionally paired with indelJexl."
+        indelJexl: "Per-bin GATK JEXL selection expressions, positionally paired with indelLabels."
+    }
+
+    input {
+        File? vcf
+        File? vcfIndex
+
+        Array[String] indelLabels
+        Array[String] indelJexl
+
+        String selectTPCall
+        String selectTPBase
+        String selectFN
+        String selectFP
+        String sampleCall
+        String sampleBase
+
+        String engine
+        String evalLabel
+        String truthLabel
+        String? stratLabel
+
+        String gatkTag
+        File? gatkJarForAnnotation
+        Array[String] annotationNames=[]
+        File reference
+        File refDict
+        File refIndex
+
+        Int? preemptible
+        Int? memoryMaybe
+    }
+
+    Int memoryDefault = 2
+    Int memoryJava = select_first([memoryMaybe,memoryDefault])
+    Int memoryRam = memoryJava+2
+
+    Int disk_size = 10 + ceil(4.2 * size(vcf, "GB") + 2.2 * size(vcfIndex, "GB") + size(reference, "GB"))
+
+    command <<<
+        set -xeuo pipefail
+
+        VCF=~{vcf}
+        if [[ ! -z "~{gatkJarForAnnotation}" ]]; then
+            java -jar ~{gatkJarForAnnotation} VariantAnnotator -V ~{vcf} -O annotated.vcf.gz ~{true="-A" false="" length(annotationNames)>0} ~{sep=" -A " annotationNames} -R ~{reference}
+            VCF=annotated.vcf.gz
+        fi
+
+        # One line per indel-length bin: <label>\t<jexl>
+        paste "~{write_lines(indelLabels)}" "~{write_lines(indelJexl)}" > bins.tsv
+
+        printf 'label\ttp_call\ttp_base\tfn\tfp\n' > counts.tsv
+        while IFS=$'\t' read -r label jexl; do
+            [ -z "${label}" ] && continue
+            gatk --java-options "-Xmx~{memoryJava}G" SelectVariants -V "${VCF}" -O sel.TP_CALL.vcf.gz -select "${jexl} && ~{selectTPCall}" -sn ~{sampleCall}
+            gatk --java-options "-Xmx~{memoryJava}G" SelectVariants -V "${VCF}" -O sel.TP_BASE.vcf.gz -select "${jexl} && ~{selectTPBase}" -sn ~{sampleBase}
+            gatk --java-options "-Xmx~{memoryJava}G" SelectVariants -V "${VCF}" -O sel.FN.vcf.gz -select "${jexl} && ~{selectFN}" -sn ~{sampleBase}
+            gatk --java-options "-Xmx~{memoryJava}G" SelectVariants -V "${VCF}" -O sel.FP.vcf.gz -select "${jexl} && ~{selectFP}" -sn ~{sampleCall}
+            TP_CALL="$(gatk --java-options "-Xmx~{memoryJava}G" CountVariants -V sel.TP_CALL.vcf.gz | tail -1)"
+            TP_BASE="$(gatk --java-options "-Xmx~{memoryJava}G" CountVariants -V sel.TP_BASE.vcf.gz | tail -1)"
+            FN="$(gatk --java-options "-Xmx~{memoryJava}G" CountVariants -V sel.FN.vcf.gz | tail -1)"
+            FP="$(gatk --java-options "-Xmx~{memoryJava}G" CountVariants -V sel.FP.vcf.gz | tail -1)"
+            printf '%s\t%s\t%s\t%s\t%s\n' "${label}" "${TP_CALL}" "${TP_BASE}" "${FN}" "${FP}" >> counts.tsv
+        done < bins.tsv
+
+        # Summarise all bins into one CSV (schema matches SummariseForIndelSelection).
+        # IndelLength parsing mirrors that task's GetSelectionValue: NA for the
+        # pure insertion/deletion bins; an 'm' prefix denotes a negative length.
+        awk -F'\t' -v name="~{evalLabel}" -v truth="~{truthLabel}" -v engine="~{engine}" -v strat="~{default="NA" stratLabel}" '
+            BEGIN { OFS=","; print "Name","Truth_Set","Comparison_Engine","Stratifier","IndelLength","Recall","Precision","TP_Base","TP_Eval","FP","FN","IGV_Session","Summary_Type","F1_Score" }
+            NR==1 { next }
+            {
+                label=$1; tpc=$2+0; tpb=$3+0; fn=$4+0; fp=$5+0;
+                type=""; len="NA";
+                if (label=="deletion")            { type="deletion" }
+                else if (label=="insertion")      { type="insertion" }
+                else if (label ~ /^indel_fine_/)  { type="indel_fine";   s=substr(label,12) }
+                else if (label ~ /^indel_coarse_/){ type="indel_coarse"; s=substr(label,14) }
+                if (type=="indel_fine" || type=="indel_coarse") {
+                    if (substr(s,1,1)=="m") { len = -(substr(s,2)+0) } else { len = s+0 }
+                }
+                recall = (tpb+fn>0) ? tpb/(tpb+fn) : "NA";
+                prec   = (tpc+fp>0) ? tpc/(tpc+fp) : "NA";
+                if (recall=="NA" || prec=="NA" || (prec+recall)==0) { f1="NA" } else { f1=2*prec*recall/(prec+recall) }
+                print name,truth,engine,strat,len,recall,prec,tpb,tpc,fp,fn,"NA",type,f1
+            }' counts.tsv > "~{engine}.indel_length.summary.csv"
+    >>>
+
+    runtime {
+        docker: "us.gcr.io/broad-gatk/gatk:"+gatkTag
+        preemptible: select_first([preemptible,0])
+        disks: "local-disk " + disk_size + " HDD"
+        bootDiskSizeGb: 16
+        memory: memoryRam + " GB"
+    }
+
+    output {
+        File summaryOut = engine + ".indel_length.summary.csv"
+    }
+}
+
+task SummariseForIndelSelection {
+    input {
+        String evalLabel
+        String truthLabel
+        String? stratLabel
+        String indelLabel
+        String engine
+        String igvSession
+        Int TP_CALL
+        Int TP_BASE
+        Int FP
+        Int FN
+        Int? preemptible
+
+    }
+
+    command <<<
+        set -xeuo pipefail
+
+        Rscript -<<"EOF" ~{TP_CALL} ~{TP_BASE} ~{FN} ~{FP} ~{evalLabel} ~{truthLabel} ~{indelLabel} ~{engine} ~{default="" stratLabel} ~{igvSession}
+        GetSelectionValue<-function(name, target) {
+
+                  if(target=="insertion" || target=="deletion") {
+                    return(NA)
+                  }
+                  pos_start<-regexpr(target,name)
+                  sub = substring(name,pos_start+attr(pos_start,"match.length")+1,nchar(name))
+                  split_sub = strsplit(sub,"_")
+                  val = if(grepl("^m",split_sub[[1]][[1]])) -as.double(gsub("m","",split_sub[[1]][[1]])) else as.double(split_sub[[1]][[1]])
+                }
+
+        args <-commandArgs(trailingOnly = TRUE)
+        indel_options <-c("deletion","insertion","indel_fine","indel_coarse")
+        indel_type <- mapply(grepl,indel_options,args[7])
+        indel_type <- indel_options[indel_type[indel_options]]
+        indel_length <- GetSelectionValue(args[7],indel_type)
+        if (length(args)<10) {
+          stratifier <- NA
+        } else {
+          stratifier <- args[9]
+        }
+        table <- data.frame("Name"=args[5], "Truth_Set"=args[6],"Comparison_Engine"=args[8],"Stratifier"=stratifier,
+                            "IndelLength"= indel_length,
+                            "Recall"=as.numeric(args[2])/(as.numeric(args[2])+as.numeric(args[3])),"Precision"=as.numeric(args[1])/(as.numeric(args[1])+as.numeric(args[4])),"TP_Base"=as.numeric(args[2]),"TP_Eval"=as.numeric(args[1]),
+                            "FP"=as.numeric(args[4]),"FN"=as.numeric(args[3]),"IGV_Session"=args[length(args)],"Summary_Type"=indel_type)
+        table$F1_Score <- 2*table$Precision*table$Recall/(table$Precision+table$Recall)
+        write.csv(table,paste(args[8],".",indel_type,".summary.csv",sep=""),row.names = FALSE)
+        EOF
+    >>>
+
+    runtime {
+            docker: "rocker/tidyverse"
+            preemptible: select_first([preemptible,0])
+            disks: "local-disk 10 HDD"
+        }
+
+    output {
+        File summaryOut = glob("*.summary.csv")[0]
+    }
+
+}
+
+#create csv file of statistics based on TP,FP,FN
+task SummariseForVariantSelection {
+    input {
+        String evalLabel
+        String truthLabel
+        String? stratLabel
+        String variantLabel
+        String engine
+        String igvSession
+        Int TP_CALL
+        Int TP_BASE
+        Int FP
+        Int FN
+        Int? preemptible
+
+    }
+
+    command <<<
+        set -xeuo pipefail
+
+        Rscript -<<"EOF" ~{TP_CALL} ~{TP_BASE} ~{FN} ~{FP} ~{evalLabel} ~{truthLabel} ~{variantLabel} ~{engine} ~{default="" stratLabel} ~{igvSession}
+        args <-commandArgs(trailingOnly = TRUE)
+        if (length(args)<10) {
+          stratifier <- NA
+        } else {
+          stratifier <- args[9]
+        }
+        table <- data.frame("Name"=args[5], "Truth_Set"=args[6],"Comparison_Engine"=args[8],"Stratifier"=stratifier,
+                            "IndelLength"= NA,
+                            "Recall"=as.numeric(args[2])/(as.numeric(args[2])+as.numeric(args[3])),"Precision"=as.numeric(args[1])/(as.numeric(args[1])+as.numeric(args[4])),"TP_Base"=as.numeric(args[2]),"TP_Eval"=as.numeric(args[1]),
+                            "FP"=as.numeric(args[4]),"FN"=as.numeric(args[3]),"IGV_Session"=args[length(args)],"Summary_Type"="summary","Type"=args[7])
+        table$F1_Score <- 2*table$Precision*table$Recall/(table$Precision+table$Recall)
+        write.csv(table,paste(args[8],".",args[7],".summary.csv",sep=""),row.names = FALSE)
+        EOF
+    >>>
+
+    runtime {
+            docker: "rocker/tidyverse"
+            preemptible: select_first([preemptible,0])
+            disks: "local-disk 10 HDD"
+        }
+
+    output {
+        File summaryOut = glob("*.summary.csv")[0]
+    }
+
+}
+
+#Convert vcfeval output statistics to final output format
+task SummariseVcfEval {
+    input {
+        String evalLabel
+        String truthLabel
+        String areVariants
+        String? igvSession
+        String? stratLabel
+        File? summaryFile
+        Int? unkSNP
+        Int? unkINDEL
+        Int? preemptible
+    }
+    Int disk_size = 10 + ceil(2.2 * size(summaryFile, "GB"))
+
+    command <<<
+        set -xeuo pipefail
+
+        Rscript -<<"EOF" ~{evalLabel} ~{truthLabel} ~{default="" summaryFile} ~{default="" stratLabel} ~{default="" igvSession} ~{default="" unkSNP} ~{default="" unkINDEL} ~{areVariants}
+        args <- commandArgs(trailingOnly = TRUE)
+        if (args[length(args)]=="yes") {
+            table_vcfeval <- read.csv(args[3])
+            if (length(args)==7) {
+                table_vcfeval$Stratifier <- NA
+                table_vcfeval$IGV_Session <- args[4]
+                table_vcfeval$UNK[table_vcfeval$Type=="SNP"]=args[5]
+                table_vcfeval$UNK[table_vcfeval$Type=="INDEL"]=args[6]
+            } else {
+                table_vcfeval$Stratifier <- args[4]
+                table_vcfeval$IGV_Session <- args[5]
+                table_vcfeval$UNK[table_vcfeval$Type=="SNP"]=args[6]
+                table_vcfeval$UNK[table_vcfeval$Type=="INDEL"]=args[7]
+            }
+            write(ifelse(is.na(table_vcfeval[table_vcfeval$Type=="SNP",  ]$Precision), 0, table_vcfeval[table_vcfeval$Type=="SNP",  ]$Precision), "snpPrecision.txt")
+            write(ifelse(is.na(table_vcfeval[table_vcfeval$Type=="INDEL",]$Precision), 0, table_vcfeval[table_vcfeval$Type=="INDEL",]$Precision), "indelPrecision.txt")
+            write(ifelse(is.na(table_vcfeval[table_vcfeval$Type=="SNP",  ]$Recall),    0, table_vcfeval[table_vcfeval$Type=="SNP",  ]$Recall),    "snpRecall.txt")
+            write(ifelse(is.na(table_vcfeval[table_vcfeval$Type=="INDEL",]$Recall),    0, table_vcfeval[table_vcfeval$Type=="INDEL",]$Recall),    "indelRecall.txt")
+            write(ifelse(is.na(table_vcfeval[table_vcfeval$Type=="SNP",  ]$F1_Score),  0, table_vcfeval[table_vcfeval$Type=="SNP",  ]$F1_Score),  "snpF1Score.txt")
+            write(ifelse(is.na(table_vcfeval[table_vcfeval$Type=="INDEL",]$F1_Score),  0, table_vcfeval[table_vcfeval$Type=="INDEL",]$F1_Score),  "indelF1Score.txt")
+        } else {
+            types <- c("INDEL","SNP")
+            recall <- c(NA,NA)
+            precision <- c(NA,NA)
+            f1_score <- c(NA,NA)
+            tp <- c(0,0)
+            fp <- c(0,0)
+            fn <- c(0,0)
+            unk <- c(0,0)
+            igv_session <- c(NA,NA)
+            table_vcfeval <- data.frame("Type"=types,"Recall"=recall,"Precision"=precision,"F1_Score"=f1_score,"TP_Base"=tp,"TP_Eval"=tp,"FP"=fp,"FN"=fn,"UNK"=unk,"IGV_Session"=igv_session)
+            if (length(args)==3) {
+                table_vcfeval$Stratifier <- NA
+            } else {
+                table_vcfeval$Stratifier <- args[3]
+            }
+            write(0,"snpPrecision.txt")
+            write(0,"indelPrecision.txt")
+            write(0,"snpRecall.txt")
+            write(0,"indelRecall.txt")
+            write(0,"snpF1Score.txt")
+            write(0,"indelF1Score.txt")
+        }
+        table_vcfeval$Name <- args[1]
+        table_vcfeval$Truth_Set <- args[2]
+        table_vcfeval$Summary_Type <- "summary"
+        table_vcfeval$Comparison_Engine <-"VcfEval"
+        write.csv(table_vcfeval,"vcfeval.summary.csv",row.names = FALSE)
+        EOF
+    >>>
+
+    runtime {
+        docker: "rocker/tidyverse"
+        preemptible: select_first([preemptible,0])
+        disks: "local-disk " + disk_size + " HDD"
+    }
+
+    output{
+        File summaryOut="vcfeval.summary.csv"
+        Float snpPrecision = read_float("snpPrecision.txt")
+        Float indelPrecision = read_float("indelPrecision.txt")
+        Float snpRecall = read_float("snpRecall.txt")
+        Float indelRecall = read_float("indelRecall.txt")
+        Float snpF1Score = read_float("snpF1Score.txt")
+        Float indelF1Score = read_float("indelF1Score.txt")
+    }
+}
+
+#Convert hap.py output statistics to final output format
+task SummariseHappy {
+     input {
+        String evalLabel
+        String truthLabel
+        String areVariants
+        String? stratLabel
+        File? summaryFile
+        Int? preemptible
+        String? igvSession
+     }
+
+     Int disk_size = 10 + ceil(2.2 * size(summaryFile, "GB"))
+
+    command <<<
+        Rscript -<<"EOF" ~{evalLabel} ~{truthLabel} ~{default="" summaryFile} ~{default="" stratLabel} ~{default="" igvSession} ~{areVariants}
+        args <-commandArgs(trailingOnly = TRUE)
+        if (args[length(args)]=="yes") {
+          table_happy <- read.csv(args[3])
+          colnames(table_happy)[10]<-"Recall"
+          colnames(table_happy)[11]<-"Precision"
+          colnames(table_happy)[13]<-"F1_Score"
+          colnames(table_happy)[4]<-"TP_Base"
+          table_happy$TP_Eval = table_happy$TP_Base
+          colnames(table_happy)[5]<-"FN"
+          colnames(table_happy)[7]<-"FP"
+          colnames(table_happy)[8]<-"UNK"
+          if (length(args)==5) {
+            table_happy$Stratifier <- NA
+            table_happy$IGV_Session <- args[4]
+          } else {
+            table_happy$Stratifier <-args[4]
+            table_happy$IGV_Session <- args[5]
+          }
+
+
+        } else {
+          types <- c("INDEL","SNP")
+          recall <- c(NA,NA)
+          precision <- c(NA,NA)
+          f1_score <- c(NA,NA)
+          igv_session <- c(NA,NA)
+          tp <- c(0,0)
+          fp <- c(0,0)
+          fn <- c(0,0)
+          unk <- c(0,0)
+          filters <- c("PASS","PASS")
+          table_happy <- data.frame("Type"=types,"Recall"=recall,"Precision"=precision,"F1_Score"=f1_score,"TP_Base"=tp,"TP_Eval"=tp,"FP"=fp,"FN"=fn,"UNK"=unk,"Filter"=filters,"IGV_Session"=igv_session)
+          if (length(args)==3) {
+            table_happy$Stratifier <- NA
+          } else {
+            table_happy$Stratifier <-args[3]
+          }
+
+        }
+        table_happy$Name <- args[1]
+        table_happy$Truth_Set <- args[2]
+        table_happy$Comparison_Engine <-"Happy"
+        table_happy$Summary_Type <- "summary"
+        table_happy<-table_happy[table_happy$Filter=="PASS",c("Type","Recall","Precision","Name","Truth_Set","Comparison_Engine","F1_Score","TP_Eval","TP_Base","FP","FN","UNK","Stratifier","IGV_Session","Summary_Type")]
+        if (nrow(subset(table_happy,Type=="INDEL"))==0) {
+          table_add <- data.frame("Type"="INDEL","Recall"=NA,"Precision"=NA,"F1_Score"=NA,"TP_Eval"=0,"TP_Base"=0,"FP"=0,"FN"=0,"UNK"=0,"Name"=args[1],"Truth_Set"=args[2],"Comparison_Engine"="Happy","Stratifier"=table_happy$Stratifier[1],"IGV_Session"=NA,"Summary_Type"="summary")
+          table_happy <- rbind(table_happy,table_add)
+        }
+        write.csv(table_happy,"happy.summary.csv",row.names = FALSE)
+        EOF
+    >>>
+
+    runtime {
+        docker: "rocker/tidyverse"
+        preemptible: select_first([preemptible,0])
+        disks: "local-disk " + disk_size + " HDD"
+    }
+
+    output{
+        File summaryOut="happy.summary.csv"
+    }
+}
+
+#Convert GenotypeConcordance output statistics to final output format
+task SummariseGATKGC {
+    input {
+        String evalLabel
+        String truthLabel
+        String areVariants
+        String? stratLabel
+        File? summaryFile
+        File? summaryCounts
+        Int? unkSNP
+        Int? unkINDEL
+        Int? preemptible
+        String? igvSession
+    }
+
+    Int disk_size = 10 + ceil(2.2 * size(summaryFile, "GB") + 2.2 * size(summaryCounts, "GB"))
+
+    command <<<
+        set -xeuo pipefail
+
+        Rscript -<<"EOF" ~{evalLabel} ~{truthLabel} ~{default="" summaryFile} ~{default="" summaryCounts} ~{default="" stratLabel} ~{default="" igvSession} ~{default="" unkSNP} ~{default="" unkINDEL} ~{areVariants}
+        args <- commandArgs(trailingOnly = TRUE)
+        if (args[length(args)]=="yes") {
+            table_GC <- read.table(args[3],skip = 6, header = TRUE,sep="\t",na.strings="?")
+            table_counts_GC <- read.table(args[4],skip = 6, header = TRUE,sep="\t",na.strings="?")
+            table_GC$F1_Score <- 2*(table_GC$VAR_PPV*table_GC$VAR_SENSITIVITY)/(table_GC$VAR_PPV+table_GC$VAR_SENSITIVITY)
+            table_GC$TP_Eval <- table_counts_GC$TP_COUNT
+            table_GC$TP_Base <- table_counts_GC$TP_COUNT
+            table_GC$FP <- table_counts_GC$FP_COUNT
+            table_GC$FN <- table_counts_GC$FN_COUNT
+            colnames(table_GC)[10]<-"Recall"
+            colnames(table_GC)[11]<-"Precision"
+            colnames(table_GC)[1]<-"Type"
+            if (length(args)==8) {
+                table_GC$Stratifier <- NA
+                table_GC$IGV_Session <- args[5]
+                table_GC$UNK[table_GC$Type=="SNP"]=args[6]
+                table_GC$UNK[table_GC$Type=="INDEL"]=args[7]
+
+            } else {
+                table_GC$Stratifier <- args[5]
+                table_GC$IGV_Session <- args[6]
+                table_GC$UNK[table_GC$Type=="SNP"]=args[7]
+                table_GC$UNK[table_GC$Type=="INDEL"]=args[8]
+            }
+        } else {
+            types <- c("INDEL","SNP")
+            recall <- c(NA,NA)
+            precision <- c(NA,NA)
+            f1_score <- c(NA,NA)
+            tp <- c(0,0)
+            fp <- c(0,0)
+            fn <- c(0,0)
+            unk <- c(0,0)
+            igv_session <- c(NA,NA)
+            table_GC <- data.frame("Type"=types,"Recall"=recall,"Precision"=precision,"F1_Score"=f1_score,"TP_Eval"=tp,"TP_Base"=tp,"FP"=fp,"FN"=fn,"UNK"=unk,"IGV_Session"=igv_session)
+            if (length(args)==3) {
+                table_GC$Stratifier <- NA
+            } else {
+                table_GC$Stratifier <- args[3]
+            }
+        }
+        table_GC$Name <- args[1]
+        table_GC$Truth_Set <- args[2]
+        table_GC$Comparison_Engine <-"GATK_GC"
+        table_GC$Summary_Type <- "summary"
+        table_GC <- table_GC[,c("Type","Recall","Precision","Name","Truth_Set","Comparison_Engine","F1_Score","TP_Eval","TP_Base","FP","FN","UNK","Stratifier","IGV_Session","Summary_Type")]
+        write.csv(table_GC,"gatkgc.summary.csv",row.names = FALSE)
+        EOF
+    >>>
+
+    runtime {
+        docker: "rocker/tidyverse"
+        preemptible: select_first([preemptible,0])
+        disks: "local-disk " + disk_size + " HDD"
+    }
+
+    output{
+        File summaryOut="gatkgc.summary.csv"
+    }
+}
+
+#Combine summaries from multiple csv into a single csv
+task CombineSummaries {
+    input {
+        Array[File] summaries
+        Int? preemptible
+    }
+    String dollar="$"
+
+    Int disk_size = 10 + ceil(2 * size(summaries, "GB"))
+    command <<<
+        set -xeuo pipefail
+
+        Rscript -<<"EOF"
+        library(readr)
+        library(dplyr)
+        library(purrr)
+        summary_files <- read_csv("~{write_lines(summaries)}", col_names = FALSE)
+        merged<- as.list(summary_files$X1) %>% map(read_csv) %>% reduce(bind_rows)
+        write.csv(merged,"summary.csv",row.names = FALSE)
+        EOF
+    >>>
+
+    runtime {
+            docker: "rocker/tidyverse"
+            preemptible: select_first([preemptible,0])
+            disks: "local-disk " + disk_size + " HDD"
+        }
+
+    output{
+        File summaryOut="summary.csv"
+    }
+}
+
+#Use CrosscheckFingerprints to match evaluation vcfs to appropriate truth vcfs
+task MatchEvalTruth {
+    input{
+        File evalVcf
+        File truthVcf
+        File evalVcfIndex
+        File truthVcfIndex
+        File hapMap
+        Int? preemptible
+        Int? memoryMaybe
+        String gatkTag
+    }
+    Int memoryDefault = 16
+    Int memoryJava = select_first([memoryMaybe,memoryDefault])
+    Int memoryRam = memoryJava+2
+    Int disk_size = 10 + ceil(size(hapMap, "GB") + size(evalVcf, "GB") + size(evalVcfIndex, "GB") + size(truthVcf, "GB") + size(truthVcfIndex, "GB"))
+
+    command <<<
+        gatk --java-options "-Xmx~{memoryJava}G" CrosscheckFingerprints -I ~{evalVcf} -SI ~{truthVcf} -H ~{hapMap} --CROSSCHECK_MODE CHECK_ALL_OTHERS --CROSSCHECK_BY FILE --EXPECT_ALL_GROUPS_TO_MATCH
+    >>>
+
+    runtime {
+            docker: "us.gcr.io/broad-gatk/gatk:"+gatkTag
+            preemptible: select_first([preemptible,0])
+            disks: "local-disk " + disk_size + " HDD"
+            bootDiskSizeGb: 16
+            memory: memoryRam + " GB"
+        }
+}
+
+# creates an IGV session
+# given a list of IGV compatible file paths
+task WriteXMLfile {
+    input {
+        Array[String] input_files
+        String reference_version
+        String file_name
+
+        Array[String]? input_names
+
+        Int? preemptible
+    }
+
+    Array[String] input_names_prefix = if defined(input_names) then prefix('-n ', select_first([input_names])) else []
+
+    command <<<
+        set -euxo pipefail
+
+        # because of some nonsense above, we need to play some bash tricks here to make sure that
+        # the inputs are labeled correctly:
+        echo '~{sep=" " input_names_prefix}' | sed -e 's#-n[ \t]*-n#-n#g' -e 's#-n[ \t]*$##' > labels.txt
+
+        bash /usr/writeIGV.sh ~{reference_version} ~{sep=" " input_files} $(cat labels.txt) > "~{file_name}.xml"
+    >>>
+    runtime {
+        docker: "quay.io/mduran/generate-igv-session_2:v1.0"
+        preemptible: select_first([preemptible,0])
+        memory: "2 GB"
+        disks: "local-disk 10 HDD"
+    }
+    output {
+        File igv_session = "${file_name}.xml"
+    }
+}
+
+task CreateIntervalList{
+    input {
+        File reference
+        File reference_index
+        File reference_dict
+        String interval_string
+        String gatkTag
+        String? dummyInputForTerraCallCaching
+    }
+    command {
+        gatk PreprocessIntervals \
+        -R ~{reference} \
+        -L ~{interval_string} \
+        -O output.interval_list \
+        --bin-length 0 \
+        -imr OVERLAPPING_ONLY \
+        -padding 0
+    }
+    output {
+        File interval_list = "output.interval_list"
+    }
+    runtime {
+        preemptible: 3
+        docker: "us.gcr.io/broad-gatk/gatk:"+gatkTag
+        disks: "local-disk 100 HDD"
+        memory: "4 GB"
+    }
+}
+
+#Print given message to stderr and return an error
+task ErrorWithMessage{
+    input {
+        String message
+    }
+    command <<<
+    >&2 echo "Error: ~{message}"
+    exit 1
+    >>>
+
+    runtime {
+        docker: "ubuntu"
+    }
+}

--- a/wdl/pipelines/TechAgnostic/Utility/BenchmarkVCFsSmall.wdl
+++ b/wdl/pipelines/TechAgnostic/Utility/BenchmarkVCFsSmall.wdl
@@ -307,8 +307,10 @@ workflow BenchmarkVCFsSmall {
                         annotationNames = annotationNames,
                         reference = ref_map["fasta"],
                         refDict = ref_map["dict"],
-                        refIndex = ref_map["fai"],
-                        preemptible = preemptible
+                        refIndex = ref_map["fai"]
+                        # Intentionally on-demand (not preemptible): this is the
+                        # longest task and it has no checkpoint, so a preemption
+                        # would restart the whole bin loop from scratch.
                 }
             }
         }
@@ -1078,11 +1080,15 @@ task EvalIndelLengthAllBins {
 
         Int? preemptible
         Int? memoryMaybe
+        Int? cpuMaybe
     }
 
     Int memoryDefault = 2
     Int memoryJava = select_first([memoryMaybe,memoryDefault])
-    Int memoryRam = memoryJava+2
+    # Bins run concurrently, one GATK JVM (-Xmx memoryJava) per worker, so the VM
+    # needs roughly cpu * memoryJava plus a couple GB of overhead.
+    Int cpu = select_first([cpuMaybe, 4])
+    Int memoryRam = cpu*memoryJava + 2
 
     Int disk_size = 10 + ceil(4.2 * size(vcf, "GB") + 2.2 * size(vcfIndex, "GB") + size(reference, "GB"))
 
@@ -1095,22 +1101,52 @@ task EvalIndelLengthAllBins {
             VCF=annotated.vcf.gz
         fi
 
+        # Pre-filter to simple indels ONCE (keeping both samples). Every per-bin
+        # selection then scans this small file instead of re-scanning the full,
+        # potentially hundreds-of-thousands-of-variant, eval VCF 4x per bin.
+        gatk --java-options "-Xmx~{memoryJava}G" SelectVariants -V "${VCF}" -O indels.vcf.gz -select "vc.isSimpleIndel()"
+
         # One line per indel-length bin: <label>\t<jexl>
         paste "~{write_lines(indelLabels)}" "~{write_lines(indelJexl)}" > bins.tsv
+        mkdir -p bin_counts
 
-        printf 'label\ttp_call\ttp_base\tfn\tfp\n' > counts.tsv
+        # Count TP_CALL/TP_BASE/FN/FP for one indel-length bin; each bin writes a
+        # uniquely-named file so concurrent workers never race.
+        run_bin() {
+            local label="$1" jexl="$2"
+            gatk --java-options "-Xmx~{memoryJava}G" SelectVariants -V indels.vcf.gz -O "sel.${label}.TP_CALL.vcf.gz" -select "${jexl} && ~{selectTPCall}" -sn ~{sampleCall}
+            gatk --java-options "-Xmx~{memoryJava}G" SelectVariants -V indels.vcf.gz -O "sel.${label}.TP_BASE.vcf.gz" -select "${jexl} && ~{selectTPBase}" -sn ~{sampleBase}
+            gatk --java-options "-Xmx~{memoryJava}G" SelectVariants -V indels.vcf.gz -O "sel.${label}.FN.vcf.gz" -select "${jexl} && ~{selectFN}" -sn ~{sampleBase}
+            gatk --java-options "-Xmx~{memoryJava}G" SelectVariants -V indels.vcf.gz -O "sel.${label}.FP.vcf.gz" -select "${jexl} && ~{selectFP}" -sn ~{sampleCall}
+            local tpc tpb fn fp
+            tpc="$(gatk --java-options "-Xmx~{memoryJava}G" CountVariants -V "sel.${label}.TP_CALL.vcf.gz" | tail -1)"
+            tpb="$(gatk --java-options "-Xmx~{memoryJava}G" CountVariants -V "sel.${label}.TP_BASE.vcf.gz" | tail -1)"
+            fn="$(gatk --java-options "-Xmx~{memoryJava}G" CountVariants -V "sel.${label}.FN.vcf.gz" | tail -1)"
+            fp="$(gatk --java-options "-Xmx~{memoryJava}G" CountVariants -V "sel.${label}.FP.vcf.gz" | tail -1)"
+            printf '%s\t%s\t%s\t%s\t%s\n' "${label}" "${tpc}" "${tpb}" "${fn}" "${fp}" > "bin_counts/${label}.txt"
+        }
+
+        # Run bins concurrently, bounded to ~{cpu} workers (a failed worker
+        # propagates via `wait -n` under `set -e`).
+        running=0
         while IFS=$'\t' read -r label jexl; do
             [ -z "${label}" ] && continue
-            gatk --java-options "-Xmx~{memoryJava}G" SelectVariants -V "${VCF}" -O sel.TP_CALL.vcf.gz -select "${jexl} && ~{selectTPCall}" -sn ~{sampleCall}
-            gatk --java-options "-Xmx~{memoryJava}G" SelectVariants -V "${VCF}" -O sel.TP_BASE.vcf.gz -select "${jexl} && ~{selectTPBase}" -sn ~{sampleBase}
-            gatk --java-options "-Xmx~{memoryJava}G" SelectVariants -V "${VCF}" -O sel.FN.vcf.gz -select "${jexl} && ~{selectFN}" -sn ~{sampleBase}
-            gatk --java-options "-Xmx~{memoryJava}G" SelectVariants -V "${VCF}" -O sel.FP.vcf.gz -select "${jexl} && ~{selectFP}" -sn ~{sampleCall}
-            TP_CALL="$(gatk --java-options "-Xmx~{memoryJava}G" CountVariants -V sel.TP_CALL.vcf.gz | tail -1)"
-            TP_BASE="$(gatk --java-options "-Xmx~{memoryJava}G" CountVariants -V sel.TP_BASE.vcf.gz | tail -1)"
-            FN="$(gatk --java-options "-Xmx~{memoryJava}G" CountVariants -V sel.FN.vcf.gz | tail -1)"
-            FP="$(gatk --java-options "-Xmx~{memoryJava}G" CountVariants -V sel.FP.vcf.gz | tail -1)"
-            printf '%s\t%s\t%s\t%s\t%s\n' "${label}" "${TP_CALL}" "${TP_BASE}" "${FN}" "${FP}" >> counts.tsv
+            run_bin "${label}" "${jexl}" &
+            running=$((running+1))
+            if [ "${running}" -ge ~{cpu} ]; then wait -n; running=$((running-1)); fi
         done < bins.tsv
+        wait
+
+        # Every bin must have produced a count file.
+        n_expected="$(grep -cve '^[[:space:]]*$' bins.tsv)"
+        n_got="$(find bin_counts -type f | wc -l)"
+        if [ "${n_got}" -ne "${n_expected}" ]; then
+            echo "ERROR: expected ${n_expected} bin count files, got ${n_got}" >&2
+            exit 1
+        fi
+
+        printf 'label\ttp_call\ttp_base\tfn\tfp\n' > counts.tsv
+        cat bin_counts/*.txt >> counts.tsv
 
         # Summarise all bins into one CSV (schema matches SummariseForIndelSelection).
         # IndelLength parsing mirrors that task's GetSelectionValue: NA for the
@@ -1138,6 +1174,7 @@ task EvalIndelLengthAllBins {
     runtime {
         docker: "us.gcr.io/broad-gatk/gatk:"+gatkTag
         preemptible: select_first([preemptible,0])
+        cpu: cpu
         disks: "local-disk " + disk_size + " HDD"
         bootDiskSizeGb: 16
         memory: memoryRam + " GB"

--- a/wdl/pipelines/TechAgnostic/Utility/BenchmarkVCFsSmall.wdl
+++ b/wdl/pipelines/TechAgnostic/Utility/BenchmarkVCFsSmall.wdl
@@ -1151,67 +1151,6 @@ task EvalIndelLengthAllBins {
     }
 }
 
-task SummariseForIndelSelection {
-    input {
-        String evalLabel
-        String truthLabel
-        String? stratLabel
-        String indelLabel
-        String engine
-        String igvSession
-        Int TP_CALL
-        Int TP_BASE
-        Int FP
-        Int FN
-        Int? preemptible
-
-    }
-
-    command <<<
-        set -xeuo pipefail
-
-        Rscript -<<"EOF" ~{TP_CALL} ~{TP_BASE} ~{FN} ~{FP} ~{evalLabel} ~{truthLabel} ~{indelLabel} ~{engine} ~{default="" stratLabel} ~{igvSession}
-        GetSelectionValue<-function(name, target) {
-
-                  if(target=="insertion" || target=="deletion") {
-                    return(NA)
-                  }
-                  pos_start<-regexpr(target,name)
-                  sub = substring(name,pos_start+attr(pos_start,"match.length")+1,nchar(name))
-                  split_sub = strsplit(sub,"_")
-                  val = if(grepl("^m",split_sub[[1]][[1]])) -as.double(gsub("m","",split_sub[[1]][[1]])) else as.double(split_sub[[1]][[1]])
-                }
-
-        args <-commandArgs(trailingOnly = TRUE)
-        indel_options <-c("deletion","insertion","indel_fine","indel_coarse")
-        indel_type <- mapply(grepl,indel_options,args[7])
-        indel_type <- indel_options[indel_type[indel_options]]
-        indel_length <- GetSelectionValue(args[7],indel_type)
-        if (length(args)<10) {
-          stratifier <- NA
-        } else {
-          stratifier <- args[9]
-        }
-        table <- data.frame("Name"=args[5], "Truth_Set"=args[6],"Comparison_Engine"=args[8],"Stratifier"=stratifier,
-                            "IndelLength"= indel_length,
-                            "Recall"=as.numeric(args[2])/(as.numeric(args[2])+as.numeric(args[3])),"Precision"=as.numeric(args[1])/(as.numeric(args[1])+as.numeric(args[4])),"TP_Base"=as.numeric(args[2]),"TP_Eval"=as.numeric(args[1]),
-                            "FP"=as.numeric(args[4]),"FN"=as.numeric(args[3]),"IGV_Session"=args[length(args)],"Summary_Type"=indel_type)
-        table$F1_Score <- 2*table$Precision*table$Recall/(table$Precision+table$Recall)
-        write.csv(table,paste(args[8],".",indel_type,".summary.csv",sep=""),row.names = FALSE)
-        EOF
-    >>>
-
-    runtime {
-            docker: "rocker/tidyverse"
-            preemptible: select_first([preemptible,0])
-            disks: "local-disk 10 HDD"
-        }
-
-    output {
-        File summaryOut = glob("*.summary.csv")[0]
-    }
-
-}
 
 #create csv file of statistics based on TP,FP,FN
 task SummariseForVariantSelection {

--- a/wdl/pipelines/TechAgnostic/Utility/BenchmarkVCFsSmall.wdl
+++ b/wdl/pipelines/TechAgnostic/Utility/BenchmarkVCFsSmall.wdl
@@ -1107,7 +1107,7 @@ task EvalIndelLengthAllBins {
         # These intermediates are only counted (never region-queried), so skip
         # output index creation: GATK 4.0.11 otherwise crashes writing the tabix
         # index for empty / contig-sparse subsets (sequenceNames.size() mismatch).
-        gatk --java-options "-Xmx~{memoryJava}G" SelectVariants -V "${VCF}" -O indels.vcf.gz -select "vc.isSimpleIndel()" --create-output-variant-index false
+        gatk --java-options "-Xmx~{memoryJava}G" SelectVariants -V "${VCF}" -O indels.vcf -select "vc.isSimpleIndel()" --create-output-variant-index false
 
         # One line per indel-length bin: <label>\t<jexl>
         paste "~{write_lines(indelLabels)}" "~{write_lines(indelJexl)}" > bins.tsv
@@ -1117,15 +1117,15 @@ task EvalIndelLengthAllBins {
         # uniquely-named file so concurrent workers never race.
         run_bin() {
             local label="$1" jexl="$2"
-            gatk --java-options "-Xmx~{memoryJava}G" SelectVariants -V indels.vcf.gz -O "sel.${label}.TP_CALL.vcf.gz" -select "${jexl} && ~{selectTPCall}" -sn ~{sampleCall} --create-output-variant-index false
-            gatk --java-options "-Xmx~{memoryJava}G" SelectVariants -V indels.vcf.gz -O "sel.${label}.TP_BASE.vcf.gz" -select "${jexl} && ~{selectTPBase}" -sn ~{sampleBase} --create-output-variant-index false
-            gatk --java-options "-Xmx~{memoryJava}G" SelectVariants -V indels.vcf.gz -O "sel.${label}.FN.vcf.gz" -select "${jexl} && ~{selectFN}" -sn ~{sampleBase} --create-output-variant-index false
-            gatk --java-options "-Xmx~{memoryJava}G" SelectVariants -V indels.vcf.gz -O "sel.${label}.FP.vcf.gz" -select "${jexl} && ~{selectFP}" -sn ~{sampleCall} --create-output-variant-index false
+            gatk --java-options "-Xmx~{memoryJava}G" SelectVariants -V indels.vcf -O "sel.${label}.TP_CALL.vcf" -select "${jexl} && ~{selectTPCall}" -sn ~{sampleCall} --create-output-variant-index false
+            gatk --java-options "-Xmx~{memoryJava}G" SelectVariants -V indels.vcf -O "sel.${label}.TP_BASE.vcf" -select "${jexl} && ~{selectTPBase}" -sn ~{sampleBase} --create-output-variant-index false
+            gatk --java-options "-Xmx~{memoryJava}G" SelectVariants -V indels.vcf -O "sel.${label}.FN.vcf" -select "${jexl} && ~{selectFN}" -sn ~{sampleBase} --create-output-variant-index false
+            gatk --java-options "-Xmx~{memoryJava}G" SelectVariants -V indels.vcf -O "sel.${label}.FP.vcf" -select "${jexl} && ~{selectFP}" -sn ~{sampleCall} --create-output-variant-index false
             local tpc tpb fn fp
-            tpc="$(gatk --java-options "-Xmx~{memoryJava}G" CountVariants -V "sel.${label}.TP_CALL.vcf.gz" | tail -1)"
-            tpb="$(gatk --java-options "-Xmx~{memoryJava}G" CountVariants -V "sel.${label}.TP_BASE.vcf.gz" | tail -1)"
-            fn="$(gatk --java-options "-Xmx~{memoryJava}G" CountVariants -V "sel.${label}.FN.vcf.gz" | tail -1)"
-            fp="$(gatk --java-options "-Xmx~{memoryJava}G" CountVariants -V "sel.${label}.FP.vcf.gz" | tail -1)"
+            tpc="$(gatk --java-options "-Xmx~{memoryJava}G" CountVariants -V "sel.${label}.TP_CALL.vcf" | tail -1)"
+            tpb="$(gatk --java-options "-Xmx~{memoryJava}G" CountVariants -V "sel.${label}.TP_BASE.vcf" | tail -1)"
+            fn="$(gatk --java-options "-Xmx~{memoryJava}G" CountVariants -V "sel.${label}.FN.vcf" | tail -1)"
+            fp="$(gatk --java-options "-Xmx~{memoryJava}G" CountVariants -V "sel.${label}.FP.vcf" | tail -1)"
             printf '%s\t%s\t%s\t%s\t%s\n' "${label}" "${tpc}" "${tpb}" "${fn}" "${fp}" > "bin_counts/${label}.txt"
             # Progress line (grep 'PROGRESS:' in this task's stderr to monitor).
             echo "$(date -u '+%H:%M:%S') PROGRESS: $(find bin_counts -type f | wc -l)/${TOTAL_BINS} indel bins complete (last: ${label})" >&2

--- a/wdl/pipelines/Z_One_Off_Analyses/Pf7JointGenotyping.wdl
+++ b/wdl/pipelines/Z_One_Off_Analyses/Pf7JointGenotyping.wdl
@@ -50,7 +50,10 @@ workflow Pf7JointGenotyping {
     Float  vqslod_threshold = 2.0
 
     String gatk_docker = "broadinstitute/gatk:4.1.4.0"
-    String bcftools_docker = "quay.io/biocontainers/bcftools:1.13--h3a49de5_0"
+    # lr-basic is Debian-based (GNU coreutils: MakeIntervals needs `split -d`) and ships
+    # bcftools. The quay biocontainers bcftools image is Alpine/BusyBox, whose `split`
+    # lacks -d, so MakeIntervals died with `split: invalid option -- 'd'`.
+    String bcftools_docker = "us.gcr.io/broad-dsp-lrma/lr-basic:0.1.1"
   }
 
   # 1) tile genome into interval_size windows, then bin into <=max_shards shard TSVs

--- a/wdl/pipelines/Z_One_Off_Analyses/Pf7JointGenotyping.wdl
+++ b/wdl/pipelines/Z_One_Off_Analyses/Pf7JointGenotyping.wdl
@@ -45,6 +45,11 @@ workflow Pf7JointGenotyping {
     Int    interval_size   = 10000
     Int    interval_pad    = 500
     Int    max_shards      = 10
+    # Contigs dropped from joint genotyping. The Pf organellar contigs are excluded:
+    # the mitochondrion (Pf3D7_MIT_v3, 5,967 bp) is shorter than one padded interval
+    # and GenomicsDBImport rejects the apicoplast window (Pf3D7_API_v3:1-10000 +ip),
+    # which failed the last shard. Nuclear-only joint calling is the intended scope.
+    Array[String] contigs_to_exclude = ["Pf3D7_API_v3", "Pf3D7_MIT_v3"]
     Float  vqsr_prior      = 15.0
     Int    vqsr_max_gaussians = 8
     Float  vqslod_threshold = 2.0
@@ -59,7 +64,8 @@ workflow Pf7JointGenotyping {
   # 1) tile genome into interval_size windows, then bin into <=max_shards shard TSVs
   call MakeIntervals {
     input: ref_fasta_fai = ref_fasta_fai, interval_size = interval_size,
-           max_shards = max_shards, bcftools_docker = bcftools_docker
+           max_shards = max_shards, contigs_to_exclude = contigs_to_exclude,
+           bcftools_docker = bcftools_docker
   }
 
   # 2) derive the sample-name-map ONCE from the gVCF headers (streams the gVCFs,
@@ -118,14 +124,21 @@ task MakeIntervals {
     File ref_fasta_fai
     Int interval_size
     Int max_shards
+    Array[String] contigs_to_exclude = []
     String bcftools_docker
   }
   command <<<
     set -euo pipefail
+    # Tile each contig into fixed windows (contig<TAB>start<TAB>end, 1-based inclusive),
+    # skipping any contig named in contigs_to_exclude (e.g. Pf organellar contigs, whose
+    # short/padded windows break downstream GenomicsDBImport).
     awk -v W=~{interval_size} 'BEGIN{OFS="\t"}
+      NR==FNR { ex[$1]=1; next }                 # first file: excluded contig names
+      ($1 in ex) { next }                        # skip excluded contigs
       { len=$2; s=1; while (s<=len){ e=s+W-1; if(e>len)e=len; print $1,s,e; s=e+1 } }' \
-      ~{ref_fasta_fai} > intervals.tsv
+      ~{write_lines(contigs_to_exclude)} ~{ref_fasta_fai} > intervals.tsv
 
+    echo "excluded contigs: ~{sep=' ' contigs_to_exclude}" 1>&2
     N=$(wc -l < intervals.tsv)
     S=~{max_shards}; if [ "$N" -lt "$S" ]; then S=$N; fi
     PER=$(( (N + S - 1) / S ))                 # ceil(N/S) intervals per shard

--- a/wdl/pipelines/Z_One_Off_Analyses/Pf7JointGenotyping.wdl
+++ b/wdl/pipelines/Z_One_Off_Analyses/Pf7JointGenotyping.wdl
@@ -1,0 +1,373 @@
+version 1.0
+
+## Pf7JointGenotyping.wdl
+## Joint genotyping following the MalariaGEN Pf7 methods (pp.1-2):
+##   genome tiled in 10 kbp intervals (2,342 across 3D7 v3)
+##   per interval: GenomicsDBImport (-ip 500, --sample-name-map)
+##                 -> GenotypeGVCFs 4.1.4.0 (--only-output-calls-starting-in-intervals
+##                    --use-new-qual-calculator -L <int + 500bp before>
+##                    --annotation-group StandardAnnotation --annotation-group AS_StandardAnnotation)
+##                 -> excise 500bp padding (SelectVariants -L <pure window>)
+##   gather -> VQSR (SNP & indel separate; train = Pf crosses 1.0 PASS, prior 15;
+##             -an QD -an FS -an SOR -an MQRankSum -an ReadPosRankSum, no DP/MQ;
+##             --maxGaussians 8) -> VQSLOD<2.0 filter in core -> merge core/non-core.
+## Ingests the gVCFs produced by Pf7SingleSampleVariantCalling.wdl.
+##
+## SCATTER WIDTH: the 2,342 intervals are BINNED into at most `max_shards`
+## contiguous shards (default 10). Each shard task processes its intervals
+## sequentially, so the fan-out is <=10 VMs, not 2,342. Contiguous binning keeps
+## the intervals genome-ordered, so the final concat needs no re-sort.
+##
+## Each task uses only tools present in its image: GATK tasks in the gatk image,
+## VCF-wrangling (concat/filter/merge) in the bcftools image. Pf7 excised padding
+## with `bcftools view -r`; we use `gatk SelectVariants -L` (equivalent) to keep
+## the shard task in the gatk image. Pf7's final core/non-core merge used GATK3.8
+## CombineVariants; we use bcftools concat (documented divergence).
+
+workflow Pf7JointGenotyping {
+  input {
+    String cohort_name = "pf7_cohort"
+    # Sample names are DERIVED from the gVCF headers (bcftools query -l) — no
+    # hand-maintained name array (mirrors long-read-pipelines CreateSampleNameMap).
+    Array[File]   gvcfs
+    Array[File]   gvcf_indices
+
+    # Reference: PlasmoDB-61 3D7 v3 (defaults = broad-malaria-public / sr-malaria workspace)
+    File ref_fasta     = "gs://broad-malaria-public/short_read_workspace_data/reference/PlasmoDB-61_Pfalciparum3D7_Genome.fasta"
+    File ref_fasta_fai = "gs://broad-malaria-public/short_read_workspace_data/reference/PlasmoDB-61_Pfalciparum3D7_Genome.fasta.fai"
+    File ref_dict      = "gs://broad-malaria-public/short_read_workspace_data/reference/PlasmoDB-61_Pfalciparum3D7_Genome.dict"
+
+    # Pf crosses 1.0 PASS (VQSR training) + core-region bed (defaults = workspace constants)
+    File pfcrosses_pass_vcf       = "gs://broad-malaria-public/short_read_workspace_data/ALL_CROSSES.sites_only.PASS.vcf.gz"
+    File pfcrosses_pass_vcf_index = "gs://broad-malaria-public/short_read_workspace_data/ALL_CROSSES.sites_only.PASS.vcf.gz.tbi"
+    File core_bed                 = "gs://broad-malaria-public/short_read_workspace_data/regions/regions-20130225.Core.bed"
+
+    Int    interval_size   = 10000
+    Int    interval_pad    = 500
+    Int    max_shards      = 10
+    Float  vqsr_prior      = 15.0
+    Int    vqsr_max_gaussians = 8
+    Float  vqslod_threshold = 2.0
+
+    String gatk_docker = "broadinstitute/gatk:4.1.4.0"
+    String bcftools_docker = "quay.io/biocontainers/bcftools:1.13--h3a49de5_0"
+  }
+
+  # 1) tile genome into interval_size windows, then bin into <=max_shards shard TSVs
+  call MakeIntervals {
+    input: ref_fasta_fai = ref_fasta_fai, interval_size = interval_size,
+           max_shards = max_shards, bcftools_docker = bcftools_docker
+  }
+
+  # 2) derive the sample-name-map ONCE from the gVCF headers (streams the gVCFs,
+  #    no localization). name<TAB>gs://path — consumed by every shard's import.
+  call CreateSampleNameMap {
+    input: gvcfs = gvcfs, gvcf_indices = gvcf_indices, prefix = cohort_name
+  }
+
+  # 3) per shard (<=10): loop its intervals -> GenomicsDBImport -> GenotypeGVCFs
+  #    -> excise padding -> merge the shard's interval VCFs into one shard VCF
+  scatter (shard_tsv in MakeIntervals.shard_tsvs) {
+    call GenotypeShard {
+      input:
+        shard_tsv = shard_tsv, pad = interval_pad,
+        sample_name_map = CreateSampleNameMap.sample_name_map,
+        ref_fasta = ref_fasta, ref_fasta_fai = ref_fasta_fai, ref_dict = ref_dict,
+        gatk_docker = gatk_docker
+    }
+  }
+
+  # 3) gather shard VCFs (genome order — shards are contiguous & lexically ordered)
+  call GatherVcfs {
+    input: cohort_name = cohort_name,
+           interval_vcfs = GenotypeShard.shard_vcf, interval_vcf_indices = GenotypeShard.shard_vcf_index,
+           bcftools_docker = bcftools_docker
+  }
+
+  # 4a) VQSR annotate (SNP & indel separate) -> VQSLOD in INFO
+  call VQSRAnnotate {
+    input: cohort_vcf = GatherVcfs.cohort_vcf, cohort_vcf_index = GatherVcfs.cohort_vcf_index,
+           ref_fasta = ref_fasta, ref_fasta_fai = ref_fasta_fai, ref_dict = ref_dict,
+           pfcrosses_pass_vcf = pfcrosses_pass_vcf, pfcrosses_pass_vcf_index = pfcrosses_pass_vcf_index,
+           vqsr_prior = vqsr_prior, vqsr_max_gaussians = vqsr_max_gaussians, gatk_docker = gatk_docker
+  }
+
+  # 4b) VQSLOD<threshold in core, keep non-core, merge -> final multisample VCF
+  call FilterMerge {
+    input: cohort_name = cohort_name,
+           snp_vqslod_vcf = VQSRAnnotate.snp_vqslod_vcf, snp_vqslod_vcf_index = VQSRAnnotate.snp_vqslod_vcf_index,
+           indel_vqslod_vcf = VQSRAnnotate.indel_vqslod_vcf, indel_vqslod_vcf_index = VQSRAnnotate.indel_vqslod_vcf_index,
+           core_bed = core_bed, vqslod_threshold = vqslod_threshold, bcftools_docker = bcftools_docker
+  }
+
+  output {
+    File cohort_genotyped_vcf = GatherVcfs.cohort_vcf
+    File cohort_genotyped_vcf_index = GatherVcfs.cohort_vcf_index
+    File cohort_filtered_vcf  = FilterMerge.filtered_vcf
+    File cohort_filtered_vcf_index = FilterMerge.filtered_vcf_index
+  }
+}
+
+# tile each contig into fixed windows (contig<TAB>start<TAB>end, 1-based inclusive),
+# then split the ordered interval list into <=max_shards contiguous shard TSVs.
+task MakeIntervals {
+  input {
+    File ref_fasta_fai
+    Int interval_size
+    Int max_shards
+    String bcftools_docker
+  }
+  command <<<
+    set -euo pipefail
+    awk -v W=~{interval_size} 'BEGIN{OFS="\t"}
+      { len=$2; s=1; while (s<=len){ e=s+W-1; if(e>len)e=len; print $1,s,e; s=e+1 } }' \
+      ~{ref_fasta_fai} > intervals.tsv
+
+    N=$(wc -l < intervals.tsv)
+    S=~{max_shards}; if [ "$N" -lt "$S" ]; then S=$N; fi
+    PER=$(( (N + S - 1) / S ))                 # ceil(N/S) intervals per shard
+    split -d -a 3 -l "$PER" intervals.tsv shard_
+    for f in shard_[0-9][0-9][0-9]; do mv "$f" "$f.tsv"; done
+    echo "intervals=$N shards=$(ls shard_*.tsv | wc -l) per_shard=$PER" 1>&2
+  >>>
+  runtime {
+    docker: bcftools_docker
+    memory: "2 GB"
+    disks: "local-disk 10 HDD"
+  }
+  output {
+    File intervals_tsv = "intervals.tsv"
+    Array[File] shard_tsvs = glob("shard_*.tsv")
+  }
+}
+
+# Derive the GenomicsDB sample-name-map from the gVCF headers (mirrors
+# broadinstitute/long-read-pipelines SRJointGenotyping.CreateSampleNameMap):
+# stream each gVCF (localization_optional -> paths stay gs://), read its one
+# sample name with `bcftools query -l`, validate, and write name<TAB>gs://path.
+# Runs ONCE; the same map feeds every shard's GenomicsDBImport, which streams the
+# gVCFs straight from those gs:// paths (no localization of thousands of files).
+task CreateSampleNameMap {
+  input {
+    Array[File] gvcfs
+    Array[File] gvcf_indices
+    String prefix
+    # lr-basic carries bcftools + gcloud (needed to mint GCS_OAUTH_TOKEN for streaming)
+    String docker = "us.gcr.io/broad-dsp-lrma/lr-basic:0.1.1"
+    Int memory_gb = 3
+    Int disk_gb = 20
+  }
+  parameter_meta {
+    gvcfs: { localization_optional: true }
+    gvcf_indices: { localization_optional: true }
+  }
+  command <<<
+    set -euxo pipefail
+    gvcf_list=~{write_lines(gvcfs)}
+    idx_list=~{write_lines(gvcf_indices)}
+    # one index per gVCF (the .tbi must sit beside each gVCF for GATK streaming)
+    [ "$(wc -l < "$gvcf_list")" -eq "$(wc -l < "$idx_list")" ] || { echo "gvcfs/indices count mismatch" >&2; exit 1; }
+
+    out="~{prefix}.sample_name_map.tsv"; : > "$out"
+    GCS_OAUTH_TOKEN=$(gcloud auth application-default print-access-token); export GCS_OAUTH_TOKEN
+
+    n=0
+    while read -r gvcf; do
+      bcftools query -l "$gvcf" > sn.txt
+      [ "$(wc -l < sn.txt)" -eq 1 ] || { echo "GVCF must contain exactly one sample: $gvcf" >&2; exit 1; }
+      grep -qi 'unnamedsample' sn.txt && { echo "GVCF sample name is 'unnamedsample': $gvcf" >&2; exit 1; }
+      printf '%s\t%s\n' "$(cat sn.txt)" "$gvcf" >> "$out"
+      n=$((n+1))
+      # periodically refresh the token so long lists don't outlive it
+      if [ "$n" -ge 50 ]; then GCS_OAUTH_TOKEN=$(gcloud auth application-default print-access-token); export GCS_OAUTH_TOKEN; n=0; fi
+    done < "$gvcf_list"
+  >>>
+  runtime {
+    docker: docker
+    memory: memory_gb + " GB"
+    disks: "local-disk " + disk_gb + " HDD"
+  }
+  output {
+    File sample_name_map = "~{prefix}.sample_name_map.tsv"
+  }
+}
+
+# One SHARD (GATK only): loop the shard's intervals, and for each run the exact
+# Pf7 per-window path (GenomicsDBImport -ip pad -> GenotypeGVCFs Pf7 flags ->
+# SelectVariants excise pad), then MergeVcfs the shard's interval VCFs into one.
+# ponytail: one JVM spin per interval (~235 intervals/shard at default 10 shards).
+#           Correct & Pf7-exact; if the JVM startup cost dominates, batch multiple
+#           -L windows into a single GenomicsDBImport/GenotypeGVCFs call.
+task GenotypeShard {
+  input {
+    File shard_tsv
+    Int pad
+    File sample_name_map          # name<TAB>gs://gvcf ; gVCFs streamed by GATK (not localized)
+    File ref_fasta
+    File ref_fasta_fai
+    File ref_dict
+    String gatk_docker
+    Int memory_gb = 10
+    Int disk_gb = 100
+  }
+  command <<<
+    set -euo pipefail
+
+    mkdir -p out
+    i=0
+    while IFS=$'\t' read -r contig start end; do
+      [ -z "${contig:-}" ] && continue
+      i=$((i+1)); iv=$(printf 'iv_%05d' "$i")
+
+      rm -rf gdb
+      gatk --java-options "-Xmx~{memory_gb - 2}g" GenomicsDBImport \
+        --sample-name-map ~{sample_name_map} \
+        -L "$contig:$start-$end" -ip ~{pad} \
+        --genomicsdb-workspace-path gdb --batch-size 50 --reader-threads 5 --merge-input-intervals
+
+      pad_start=$(( start - ~{pad} )); if [ "$pad_start" -lt 1 ]; then pad_start=1; fi
+      gatk --java-options "-Xmx~{memory_gb - 2}g" GenotypeGVCFs \
+        -R ~{ref_fasta} -V gendb://gdb \
+        -L "$contig:$pad_start-$end" \
+        --only-output-calls-starting-in-intervals \
+        --use-new-qual-calculator \
+        --annotation-group StandardAnnotation --annotation-group AS_StandardAnnotation \
+        -O padded.vcf.gz
+
+      # excise the 500bp-before padding -> pure window (Pf7 used `bcftools view -r`)
+      gatk SelectVariants -R ~{ref_fasta} -V padded.vcf.gz \
+        -L "$contig:$start-$end" -O "out/$iv.vcf.gz"
+    done < ~{shard_tsv}
+
+    # merge this shard's interval VCFs into one shard VCF (MergeVcfs sorts + indexes)
+    ls -1 out/*.vcf.gz | sort > vcf.list
+    gatk --java-options "-Xmx~{memory_gb - 2}g" MergeVcfs -I vcf.list -O shard.vcf.gz
+  >>>
+  runtime {
+    docker: gatk_docker
+    memory: memory_gb + " GB"
+    disks: "local-disk " + disk_gb + " HDD"
+  }
+  output {
+    File shard_vcf = "shard.vcf.gz"
+    File shard_vcf_index = "shard.vcf.gz.tbi"
+  }
+}
+
+# concat scattered shard VCFs into the cohort VCF (genome order)
+task GatherVcfs {
+  input {
+    String cohort_name
+    Array[File] interval_vcfs
+    Array[File] interval_vcf_indices
+    String bcftools_docker
+    Int disk_gb = 50
+  }
+  command <<<
+    set -euo pipefail
+    printf '%s\n' ~{sep=' ' interval_vcfs} > vcf.list
+    bcftools concat -a -f vcf.list -Oz -o ~{cohort_name}.genotyped.vcf.gz
+    bcftools index -t ~{cohort_name}.genotyped.vcf.gz
+  >>>
+  runtime {
+    docker: bcftools_docker
+    memory: "4 GB"
+    disks: "local-disk " + disk_gb + " HDD"
+  }
+  output {
+    File cohort_vcf = "~{cohort_name}.genotyped.vcf.gz"
+    File cohort_vcf_index = "~{cohort_name}.genotyped.vcf.gz.tbi"
+  }
+}
+
+# GATK VQSR: VariantRecalibrator + ApplyVQSR for SNP and INDEL separately.
+# ApplyVQSR at ts 100 => annotate VQSLOD without tranche-filtering (thresholded later).
+task VQSRAnnotate {
+  input {
+    File cohort_vcf
+    File cohort_vcf_index
+    File ref_fasta
+    File ref_fasta_fai
+    File ref_dict
+    File pfcrosses_pass_vcf
+    File pfcrosses_pass_vcf_index
+    Float vqsr_prior
+    Int   vqsr_max_gaussians
+    String gatk_docker
+    Int memory_gb = 16
+    Int disk_gb = 50
+  }
+  command <<<
+    set -euo pipefail
+    for mode in SNP INDEL; do
+      tag=$(echo "$mode" | tr '[:upper:]' '[:lower:]')
+      gatk --java-options "-Xmx~{memory_gb - 4}g" VariantRecalibrator \
+        -R ~{ref_fasta} -V ~{cohort_vcf} -mode "$mode" \
+        --resource:pfcrosses,known=false,training=true,truth=true,prior=~{vqsr_prior} ~{pfcrosses_pass_vcf} \
+        -an QD -an FS -an SOR -an MQRankSum -an ReadPosRankSum \
+        --trust-all-polymorphic --max-gaussians ~{vqsr_max_gaussians} \
+        -O "$tag.recal" --tranches-file "$tag.tranches"
+      gatk --java-options "-Xmx~{memory_gb - 4}g" ApplyVQSR \
+        -R ~{ref_fasta} -V ~{cohort_vcf} -mode "$mode" \
+        --recal-file "$tag.recal" --tranches-file "$tag.tranches" \
+        --truth-sensitivity-filter-level 100.0 \
+        -O "$tag.vqslod.vcf.gz"
+    done
+  >>>
+  runtime {
+    docker: gatk_docker
+    memory: memory_gb + " GB"
+    disks: "local-disk " + disk_gb + " HDD"
+  }
+  output {
+    File snp_vqslod_vcf = "snp.vqslod.vcf.gz"
+    File snp_vqslod_vcf_index = "snp.vqslod.vcf.gz.tbi"
+    File indel_vqslod_vcf = "indel.vqslod.vcf.gz"
+    File indel_vqslod_vcf_index = "indel.vqslod.vcf.gz.tbi"
+  }
+}
+
+# Take SNPs from SNP-recal + indels from INDEL-recal; VQSLOD<threshold filtered in
+# core; non-core kept unconditionally; merge -> final multisample VCF.
+task FilterMerge {
+  input {
+    String cohort_name
+    File snp_vqslod_vcf
+    File snp_vqslod_vcf_index
+    File indel_vqslod_vcf
+    File indel_vqslod_vcf_index
+    File core_bed
+    Float vqslod_threshold
+    String bcftools_docker
+    Int memory_gb = 8
+    Int disk_gb = 50
+  }
+  command <<<
+    set -euo pipefail
+    bcftools view -v snps   -Oz -o snps.vcf.gz   ~{snp_vqslod_vcf};   bcftools index -t snps.vcf.gz
+    bcftools view -v indels -Oz -o indels.vcf.gz ~{indel_vqslod_vcf}; bcftools index -t indels.vcf.gz
+    bcftools concat -a snps.vcf.gz indels.vcf.gz | bcftools sort -Oz -o vqslod.vcf.gz
+    bcftools index -t vqslod.vcf.gz
+
+    # core: keep VQSLOD >= threshold ; non-core: keep unconditionally
+    bcftools view -R ~{core_bed} vqslod.vcf.gz \
+      | bcftools view -e "INFO/VQSLOD < ~{vqslod_threshold}" -Oz -o core.pass.vcf.gz
+    bcftools index -t core.pass.vcf.gz
+    bcftools view -T "^~{core_bed}" vqslod.vcf.gz -Oz -o noncore.keep.vcf.gz
+    bcftools index -t noncore.keep.vcf.gz
+
+    # Pf7 used GATK3.8 CombineVariants; bcftools concat here (documented divergence).
+    bcftools concat -a core.pass.vcf.gz noncore.keep.vcf.gz \
+      | bcftools sort -Oz -o ~{cohort_name}.filtered.vcf.gz
+    bcftools index -t ~{cohort_name}.filtered.vcf.gz
+  >>>
+  runtime {
+    docker: bcftools_docker
+    memory: memory_gb + " GB"
+    disks: "local-disk " + disk_gb + " HDD"
+  }
+  output {
+    File filtered_vcf = "~{cohort_name}.filtered.vcf.gz"
+    File filtered_vcf_index = "~{cohort_name}.filtered.vcf.gz.tbi"
+  }
+}

--- a/wdl/pipelines/Z_One_Off_Analyses/Pf7SingleSampleVariantCalling.wdl
+++ b/wdl/pipelines/Z_One_Off_Analyses/Pf7SingleSampleVariantCalling.wdl
@@ -1,0 +1,246 @@
+version 1.0
+
+## Pf7SingleSampleVariantCalling.wdl
+## Per-sample variant calling following the MalariaGEN Pf7 methods
+## (Wellcome Open Res 2023, doi:10.12688/wellcomeopenres.18681.1, pp.1-2).
+## STARTS FROM AN ANALYSIS-READY BAM — alignment (bwa mem 0.7.15 -M),
+## samtools fixmate, Picard MarkDuplicates, and GATK BQSR are all assumed done
+## upstream. This workflow runs, for one sample:
+##   HaplotypeCaller 4.1.4.0  -contamination 0 -ERC GVCF   -> per-sample gVCF
+##   GenotypeGVCFs 4.1.4.0    (Pf7 flags, whole-genome)    -> genotyped VCF
+##   VQSR (SNP & INDEL separate; train = Pf crosses 1.0 PASS, prior 15;
+##         -an QD -an FS -an SOR -an MQRankSum -an ReadPosRankSum, --maxGaussians 8)
+##   VQSLOD<2.0 filter in core, keep non-core, merge              -> filtered VCF
+##
+## NOTE ON SINGLE-SAMPLE VQSR: VariantRecalibrator is built for cohort-scale data
+## and may fail ("no data / zero variance in annotations") on a single sample.
+## The Pf7 headline callset is a JOINT-genotyped multisample VCF — for that, run
+## Pf7JointGenotyping.wdl over the full cohort. This workflow produces the
+## single-sample VCF for the sample-level QC / comparison case.
+##
+## Each task uses only tools in its image: GATK tasks in the gatk image,
+## VCF-wrangling (concat/filter/merge) in the bcftools image.
+
+workflow Pf7SingleSampleVariantCalling {
+  input {
+    String sample_name
+    # Analysis-ready reads: aligned, dup-marked, BQSR-recalibrated BAM (+ index).
+    File analysis_ready_bam
+    File analysis_ready_bai
+
+    # Reference: PlasmoDB-61 3D7 v3 (defaults = broad-malaria-public / sr-malaria workspace)
+    File ref_fasta     = "gs://broad-malaria-public/short_read_workspace_data/reference/PlasmoDB-61_Pfalciparum3D7_Genome.fasta"
+    File ref_fasta_fai = "gs://broad-malaria-public/short_read_workspace_data/reference/PlasmoDB-61_Pfalciparum3D7_Genome.fasta.fai"
+    File ref_dict      = "gs://broad-malaria-public/short_read_workspace_data/reference/PlasmoDB-61_Pfalciparum3D7_Genome.dict"
+
+    # Pf crosses 1.0 PASS (VQSR training) + core-region bed (defaults = workspace constants)
+    File pfcrosses_pass_vcf       = "gs://broad-malaria-public/short_read_workspace_data/ALL_CROSSES.sites_only.PASS.vcf.gz"
+    File pfcrosses_pass_vcf_index = "gs://broad-malaria-public/short_read_workspace_data/ALL_CROSSES.sites_only.PASS.vcf.gz.tbi"
+    File core_bed                 = "gs://broad-malaria-public/short_read_workspace_data/regions/regions-20130225.Core.bed"
+
+    Float vqsr_prior         = 15.0
+    Int   vqsr_max_gaussians = 8
+    Float vqslod_threshold   = 2.0
+
+    String gatk_docker     = "broadinstitute/gatk:4.1.4.0"
+    String bcftools_docker = "quay.io/biocontainers/bcftools:1.13--h3a49de5_0"
+  }
+
+  # 1) analysis-ready BAM -> per-sample gVCF
+  call HaplotypeCallerGVCF {
+    input: sample_name = sample_name,
+           input_bam = analysis_ready_bam, input_bai = analysis_ready_bai,
+           ref_fasta = ref_fasta, ref_fasta_fai = ref_fasta_fai, ref_dict = ref_dict,
+           gatk_docker = gatk_docker
+  }
+
+  # 2) gVCF -> genotyped VCF (single-sample GenotypeGVCFs, whole genome, Pf7 flags)
+  call GenotypeSample {
+    input: sample_name = sample_name,
+           gvcf = HaplotypeCallerGVCF.gvcf, gvcf_index = HaplotypeCallerGVCF.gvcf_index,
+           ref_fasta = ref_fasta, ref_fasta_fai = ref_fasta_fai, ref_dict = ref_dict,
+           gatk_docker = gatk_docker
+  }
+
+  # 3) VQSR annotate (SNP & indel separate) -> VQSLOD in INFO
+  call VQSRAnnotate {
+    input: cohort_vcf = GenotypeSample.vcf, cohort_vcf_index = GenotypeSample.vcf_index,
+           ref_fasta = ref_fasta, ref_fasta_fai = ref_fasta_fai, ref_dict = ref_dict,
+           pfcrosses_pass_vcf = pfcrosses_pass_vcf, pfcrosses_pass_vcf_index = pfcrosses_pass_vcf_index,
+           vqsr_prior = vqsr_prior, vqsr_max_gaussians = vqsr_max_gaussians, gatk_docker = gatk_docker
+  }
+
+  # 4) VQSLOD<threshold in core, keep non-core, merge -> final single-sample VCF
+  call FilterMerge {
+    input: cohort_name = sample_name,
+           snp_vqslod_vcf = VQSRAnnotate.snp_vqslod_vcf, snp_vqslod_vcf_index = VQSRAnnotate.snp_vqslod_vcf_index,
+           indel_vqslod_vcf = VQSRAnnotate.indel_vqslod_vcf, indel_vqslod_vcf_index = VQSRAnnotate.indel_vqslod_vcf_index,
+           core_bed = core_bed, vqslod_threshold = vqslod_threshold, bcftools_docker = bcftools_docker
+  }
+
+  output {
+    File gvcf                 = HaplotypeCallerGVCF.gvcf
+    File gvcf_index           = HaplotypeCallerGVCF.gvcf_index
+    File genotyped_vcf        = GenotypeSample.vcf
+    File genotyped_vcf_index  = GenotypeSample.vcf_index
+    File filtered_vcf         = FilterMerge.filtered_vcf
+    File filtered_vcf_index   = FilterMerge.filtered_vcf_index
+  }
+}
+
+# GATK 4.1.4.0 HaplotypeCaller -ERC GVCF (Pf7 defaults: ploidy 2, het 1e-3, indel-het 1.25e-4)
+task HaplotypeCallerGVCF {
+  input {
+    String sample_name
+    File input_bam
+    File input_bai
+    File ref_fasta
+    File ref_fasta_fai
+    File ref_dict
+    String gatk_docker
+    Int memory_gb = 12
+    Int disk_gb = 60
+  }
+  command <<<
+    set -euo pipefail
+    gatk --java-options "-Xmx~{memory_gb - 2}g" HaplotypeCaller \
+      -R ~{ref_fasta} -I ~{input_bam} \
+      -contamination 0 -ERC GVCF \
+      -O ~{sample_name}.g.vcf.gz
+  >>>
+  runtime {
+    docker: gatk_docker
+    memory: memory_gb + " GB"
+    disks: "local-disk " + disk_gb + " HDD"
+  }
+  output {
+    File gvcf = "~{sample_name}.g.vcf.gz"
+    File gvcf_index = "~{sample_name}.g.vcf.gz.tbi"
+  }
+}
+
+# Single-sample GenotypeGVCFs (whole genome). No interval scatter / padding needed
+# for one sample — Pf7's 10kb tiling is a joint-calling parallelization; for a lone
+# gVCF the whole-genome call is identical. Same Pf7 genotyping annotation flags.
+task GenotypeSample {
+  input {
+    String sample_name
+    File gvcf
+    File gvcf_index
+    File ref_fasta
+    File ref_fasta_fai
+    File ref_dict
+    String gatk_docker
+    Int memory_gb = 12
+    Int disk_gb = 50
+  }
+  command <<<
+    set -euo pipefail
+    gatk --java-options "-Xmx~{memory_gb - 2}g" GenotypeGVCFs \
+      -R ~{ref_fasta} -V ~{gvcf} \
+      --use-new-qual-calculator \
+      --annotation-group StandardAnnotation --annotation-group AS_StandardAnnotation \
+      -O ~{sample_name}.genotyped.vcf.gz
+  >>>
+  runtime {
+    docker: gatk_docker
+    memory: memory_gb + " GB"
+    disks: "local-disk " + disk_gb + " HDD"
+  }
+  output {
+    File vcf = "~{sample_name}.genotyped.vcf.gz"
+    File vcf_index = "~{sample_name}.genotyped.vcf.gz.tbi"
+  }
+}
+
+# GATK VQSR: VariantRecalibrator + ApplyVQSR for SNP and INDEL separately.
+# ApplyVQSR at ts 100 => annotate VQSLOD without tranche-filtering (thresholded later).
+task VQSRAnnotate {
+  input {
+    File cohort_vcf
+    File cohort_vcf_index
+    File ref_fasta
+    File ref_fasta_fai
+    File ref_dict
+    File pfcrosses_pass_vcf
+    File pfcrosses_pass_vcf_index
+    Float vqsr_prior
+    Int   vqsr_max_gaussians
+    String gatk_docker
+    Int memory_gb = 16
+    Int disk_gb = 50
+  }
+  command <<<
+    set -euo pipefail
+    for mode in SNP INDEL; do
+      tag=$(echo "$mode" | tr '[:upper:]' '[:lower:]')
+      gatk --java-options "-Xmx~{memory_gb - 4}g" VariantRecalibrator \
+        -R ~{ref_fasta} -V ~{cohort_vcf} -mode "$mode" \
+        --resource:pfcrosses,known=false,training=true,truth=true,prior=~{vqsr_prior} ~{pfcrosses_pass_vcf} \
+        -an QD -an FS -an SOR -an MQRankSum -an ReadPosRankSum \
+        --trust-all-polymorphic --max-gaussians ~{vqsr_max_gaussians} \
+        -O "$tag.recal" --tranches-file "$tag.tranches"
+      gatk --java-options "-Xmx~{memory_gb - 4}g" ApplyVQSR \
+        -R ~{ref_fasta} -V ~{cohort_vcf} -mode "$mode" \
+        --recal-file "$tag.recal" --tranches-file "$tag.tranches" \
+        --truth-sensitivity-filter-level 100.0 \
+        -O "$tag.vqslod.vcf.gz"
+    done
+  >>>
+  runtime {
+    docker: gatk_docker
+    memory: memory_gb + " GB"
+    disks: "local-disk " + disk_gb + " HDD"
+  }
+  output {
+    File snp_vqslod_vcf = "snp.vqslod.vcf.gz"
+    File snp_vqslod_vcf_index = "snp.vqslod.vcf.gz.tbi"
+    File indel_vqslod_vcf = "indel.vqslod.vcf.gz"
+    File indel_vqslod_vcf_index = "indel.vqslod.vcf.gz.tbi"
+  }
+}
+
+# Take SNPs from SNP-recal + indels from INDEL-recal; VQSLOD<threshold filtered in
+# core; non-core kept unconditionally; merge -> final VCF.
+task FilterMerge {
+  input {
+    String cohort_name
+    File snp_vqslod_vcf
+    File snp_vqslod_vcf_index
+    File indel_vqslod_vcf
+    File indel_vqslod_vcf_index
+    File core_bed
+    Float vqslod_threshold
+    String bcftools_docker
+    Int memory_gb = 8
+    Int disk_gb = 50
+  }
+  command <<<
+    set -euo pipefail
+    bcftools view -v snps   -Oz -o snps.vcf.gz   ~{snp_vqslod_vcf};   bcftools index -t snps.vcf.gz
+    bcftools view -v indels -Oz -o indels.vcf.gz ~{indel_vqslod_vcf}; bcftools index -t indels.vcf.gz
+    bcftools concat -a snps.vcf.gz indels.vcf.gz | bcftools sort -Oz -o vqslod.vcf.gz
+    bcftools index -t vqslod.vcf.gz
+
+    # core: keep VQSLOD >= threshold ; non-core: keep unconditionally
+    bcftools view -R ~{core_bed} vqslod.vcf.gz \
+      | bcftools view -e "INFO/VQSLOD < ~{vqslod_threshold}" -Oz -o core.pass.vcf.gz
+    bcftools index -t core.pass.vcf.gz
+    bcftools view -T "^~{core_bed}" vqslod.vcf.gz -Oz -o noncore.keep.vcf.gz
+    bcftools index -t noncore.keep.vcf.gz
+
+    # Pf7 used GATK3.8 CombineVariants; bcftools concat here (documented divergence).
+    bcftools concat -a core.pass.vcf.gz noncore.keep.vcf.gz \
+      | bcftools sort -Oz -o ~{cohort_name}.filtered.vcf.gz
+    bcftools index -t ~{cohort_name}.filtered.vcf.gz
+  >>>
+  runtime {
+    docker: bcftools_docker
+    memory: memory_gb + " GB"
+    disks: "local-disk " + disk_gb + " HDD"
+  }
+  output {
+    File filtered_vcf = "~{cohort_name}.filtered.vcf.gz"
+    File filtered_vcf_index = "~{cohort_name}.filtered.vcf.gz.tbi"
+  }
+}

--- a/wdl/pipelines/Z_One_Off_Analyses/Pf7SingleSampleVariantCalling.wdl
+++ b/wdl/pipelines/Z_One_Off_Analyses/Pf7SingleSampleVariantCalling.wdl
@@ -13,10 +13,13 @@ version 1.0
 ##   VQSLOD<2.0 filter in core, keep non-core, merge              -> filtered VCF
 ##
 ## NOTE ON SINGLE-SAMPLE VQSR: VariantRecalibrator is built for cohort-scale data
-## and may fail ("no data / zero variance in annotations") on a single sample.
-## The Pf7 headline callset is a JOINT-genotyped multisample VCF — for that, run
-## Pf7JointGenotyping.wdl over the full cohort. This workflow produces the
-## single-sample VCF for the sample-level QC / comparison case.
+## and may fail ("No data found" / zero-variance annotations) on a single sample —
+## most often the INDEL negative model. VQSR here is BEST-EFFORT: it is attempted
+## as-is, but on failure the workflow does NOT error — it ends early in success
+## with gVCF + genotyped VCF, sets vqsr_succeeded=false, and leaves filtered_vcf
+## (and the VQSLOD intermediates) absent. The Pf7 headline callset is a JOINT-
+## genotyped multisample VCF (Pf7JointGenotyping.wdl) — that is where VQSR has the
+## scale it needs. This workflow covers the sample-level QC / comparison case.
 ##
 ## Each task uses only tools in its image: GATK tasks in the gatk image,
 ## VCF-wrangling (concat/filter/merge) in the bcftools image.
@@ -70,12 +73,18 @@ workflow Pf7SingleSampleVariantCalling {
            vqsr_prior = vqsr_prior, vqsr_max_gaussians = vqsr_max_gaussians, gatk_docker = gatk_docker
   }
 
-  # 4) VQSLOD<threshold in core, keep non-core, merge -> final single-sample VCF
-  call FilterMerge {
-    input: cohort_name = sample_name,
-           snp_vqslod_vcf = VQSRAnnotate.snp_vqslod_vcf, snp_vqslod_vcf_index = VQSRAnnotate.snp_vqslod_vcf_index,
-           indel_vqslod_vcf = VQSRAnnotate.indel_vqslod_vcf, indel_vqslod_vcf_index = VQSRAnnotate.indel_vqslod_vcf_index,
-           core_bed = core_bed, vqslod_threshold = vqslod_threshold, bcftools_docker = bcftools_docker
+  # 4) Only if VQSR succeeded: VQSLOD<threshold in core, keep non-core, merge ->
+  #    filtered VCF. If VQSR failed (single-sample indel model etc.), this is
+  #    skipped and the workflow still ends in SUCCESS — filtered_vcf is absent.
+  if (VQSRAnnotate.vqsr_ok) {
+    call FilterMerge {
+      input: cohort_name = sample_name,
+             snp_vqslod_vcf = select_first([VQSRAnnotate.snp_vqslod_vcf]),
+             snp_vqslod_vcf_index = select_first([VQSRAnnotate.snp_vqslod_vcf_index]),
+             indel_vqslod_vcf = select_first([VQSRAnnotate.indel_vqslod_vcf]),
+             indel_vqslod_vcf_index = select_first([VQSRAnnotate.indel_vqslod_vcf_index]),
+             core_bed = core_bed, vqslod_threshold = vqslod_threshold, bcftools_docker = bcftools_docker
+    }
   }
 
   output {
@@ -83,8 +92,10 @@ workflow Pf7SingleSampleVariantCalling {
     File gvcf_index           = HaplotypeCallerGVCF.gvcf_index
     File genotyped_vcf        = GenotypeSample.vcf
     File genotyped_vcf_index  = GenotypeSample.vcf_index
-    File filtered_vcf         = FilterMerge.filtered_vcf
-    File filtered_vcf_index   = FilterMerge.filtered_vcf_index
+    # VQSR is best-effort on a single sample; these are absent when it fails.
+    Boolean vqsr_succeeded    = VQSRAnnotate.vqsr_ok
+    File? filtered_vcf        = FilterMerge.filtered_vcf
+    File? filtered_vcf_index  = FilterMerge.filtered_vcf_index
   }
 }
 
@@ -171,21 +182,40 @@ task VQSRAnnotate {
     Int disk_gb = 50
   }
   command <<<
-    set -euo pipefail
+    # Attempt VQSR as-is. Single-sample runs may fail — especially the INDEL
+    # negative model ("No data found": too few indels to train). Tolerate it:
+    # do NOT fail the task. On any VQSR error, drop partial outputs and report
+    # vqsr_ok=false, exit 0, so the workflow ends early in success with no
+    # filtered VCF. NOTE: set -e is intentionally OFF so we can catch failures.
+    set -uo pipefail
+    ok=true
     for mode in SNP INDEL; do
       tag=$(echo "$mode" | tr '[:upper:]' '[:lower:]')
-      gatk --java-options "-Xmx~{memory_gb - 4}g" VariantRecalibrator \
+      if ! gatk --java-options "-Xmx~{memory_gb - 4}g" VariantRecalibrator \
         -R ~{ref_fasta} -V ~{cohort_vcf} -mode "$mode" \
         --resource:pfcrosses,known=false,training=true,truth=true,prior=~{vqsr_prior} ~{pfcrosses_pass_vcf} \
         -an QD -an FS -an SOR -an MQRankSum -an ReadPosRankSum \
         --trust-all-polymorphic --max-gaussians ~{vqsr_max_gaussians} \
-        -O "$tag.recal" --tranches-file "$tag.tranches"
-      gatk --java-options "-Xmx~{memory_gb - 4}g" ApplyVQSR \
+        -O "$tag.recal" --tranches-file "$tag.tranches" ; then
+        echo "VQSR VariantRecalibrator failed for mode=$mode (likely too few $mode variants for a single sample)" >&2
+        ok=false; break
+      fi
+      if ! gatk --java-options "-Xmx~{memory_gb - 4}g" ApplyVQSR \
         -R ~{ref_fasta} -V ~{cohort_vcf} -mode "$mode" \
         --recal-file "$tag.recal" --tranches-file "$tag.tranches" \
         --truth-sensitivity-filter-level 100.0 \
-        -O "$tag.vqslod.vcf.gz"
+        -O "$tag.vqslod.vcf.gz" ; then
+        echo "VQSR ApplyVQSR failed for mode=$mode" >&2
+        ok=false; break
+      fi
     done
+
+    if [ "$ok" != "true" ]; then
+      # incomplete -> remove any partial VQSLOD outputs so the optional outputs resolve to absent
+      rm -f snp.vqslod.vcf.gz snp.vqslod.vcf.gz.tbi indel.vqslod.vcf.gz indel.vqslod.vcf.gz.tbi
+    fi
+    echo "$ok" > vqsr_ok.txt
+    exit 0
   >>>
   runtime {
     docker: gatk_docker
@@ -193,10 +223,11 @@ task VQSRAnnotate {
     disks: "local-disk " + disk_gb + " HDD"
   }
   output {
-    File snp_vqslod_vcf = "snp.vqslod.vcf.gz"
-    File snp_vqslod_vcf_index = "snp.vqslod.vcf.gz.tbi"
-    File indel_vqslod_vcf = "indel.vqslod.vcf.gz"
-    File indel_vqslod_vcf_index = "indel.vqslod.vcf.gz.tbi"
+    Boolean vqsr_ok = read_boolean("vqsr_ok.txt")
+    File? snp_vqslod_vcf = "snp.vqslod.vcf.gz"
+    File? snp_vqslod_vcf_index = "snp.vqslod.vcf.gz.tbi"
+    File? indel_vqslod_vcf = "indel.vqslod.vcf.gz"
+    File? indel_vqslod_vcf_index = "indel.vqslod.vcf.gz.tbi"
   }
 }
 

--- a/wdl/pipelines/Z_One_Off_Analyses/SRJointCallGVCFsWithGenomicsDB_Pf_Niare_VQSR.wdl
+++ b/wdl/pipelines/Z_One_Off_Analyses/SRJointCallGVCFsWithGenomicsDB_Pf_Niare_VQSR.wdl
@@ -31,6 +31,11 @@ workflow SRJointCallGVCFsWithGenomicsDB_Pf_Niare_VQSR {
         File vqsr_sites_vcf
         File vqsr_sites_vcf_index
 
+        # VQSR SNP/INDEL model --max-gaussians (default 4). Lower for small / low-variance
+        # callsets that fail to converge (a per-contig scatter can starve the model).
+        Int snp_max_gaussians   = 4
+        Int indel_max_gaussians = 4
+
         String prefix
 
         String gcs_out_root_dir
@@ -120,6 +125,7 @@ workflow SRJointCallGVCFsWithGenomicsDB_Pf_Niare_VQSR {
                 ref_dict          = ref_map['dict'],
                 sites_only_vcf = vqsr_sites_vcf,
                 sites_only_vcf_index = vqsr_sites_vcf_index,
+                max_gaussians = indel_max_gaussians,
                 prefix = prefix + "." + contig,
         }
 
@@ -142,6 +148,7 @@ workflow SRJointCallGVCFsWithGenomicsDB_Pf_Niare_VQSR {
                 ref_dict          = ref_map['dict'],
                 sites_only_vcf = vqsr_sites_vcf,
                 sites_only_vcf_index = vqsr_sites_vcf_index,
+                max_gaussians = snp_max_gaussians,
                 prefix = prefix + "." + contig,
         }
 

--- a/wdl/pipelines/Z_One_Off_Analyses/SRWholeGenome_Pf_Niare_VQSR.wdl
+++ b/wdl/pipelines/Z_One_Off_Analyses/SRWholeGenome_Pf_Niare_VQSR.wdl
@@ -46,6 +46,11 @@ workflow SRWholeGenome_Pf_Niare_VQSR {
         Boolean call_vars_on_mitochondria = false
         String mito_contig = "Pf3D7_MIT_v3"
         Array[String] contigs_names_to_ignore = ["Pf3D7_API_v3"]  ## Required for ignoring any filtering - this is kind of a hack - TODO: fix the task!
+
+        # VQSR SNP/INDEL model --max-gaussians (default 4). Lower for small / low-variance
+        # callsets that fail to converge.
+        Int snp_max_gaussians   = 4
+        Int indel_max_gaussians = 4
     }
 
     Map[String, String] ref_map = read_map(ref_map_file)
@@ -222,6 +227,7 @@ workflow SRWholeGenome_Pf_Niare_VQSR {
             ref_dict          = ref_map['dict'],
             sites_only_vcf = vqsr_sites_vcf,
             sites_only_vcf_index = vqsr_sites_vcf_index,
+            max_gaussians = indel_max_gaussians,
             prefix = participant_name + ".norm",
     }
 
@@ -244,6 +250,7 @@ workflow SRWholeGenome_Pf_Niare_VQSR {
             ref_dict          = ref_map['dict'],
             sites_only_vcf = vqsr_sites_vcf,
             sites_only_vcf_index = vqsr_sites_vcf_index,
+            max_gaussians = snp_max_gaussians,
             prefix = participant_name + ".norm",
     }
 

--- a/wdl/tasks/Z_One_Off_Analyses/Pf_Niare_HaplotypeCaller.wdl
+++ b/wdl/tasks/Z_One_Off_Analyses/Pf_Niare_HaplotypeCaller.wdl
@@ -562,6 +562,9 @@ task VariantRecalibratorIndel {
         File sites_only_vcf_index
 
         String prefix
+        # INDEL model --max-gaussians (default 4). Exposed so small / low-variance
+        # callsets (a per-contig scatter can starve the model) can be tuned per run.
+        Int max_gaussians = 4
 
         RuntimeAttr? runtime_attr_override
     }
@@ -590,7 +593,7 @@ task VariantRecalibratorIndel {
                 --trust-all-polymorphic \
                 -an QD -an DP -an FS -an SOR -an MQ \
                 -mode INDEL \
-                --max-gaussians 4 \
+                --max-gaussians ~{max_gaussians} \
                 -resource:Brown,known=true,training=true,truth=true,prior=15.0 ~{sites_only_vcf} \
                 -O ~{prefix}.indel_recal \
                 --output-model ~{prefix}.indel.model.report \
@@ -646,6 +649,9 @@ task VariantRecalibratorSnp {
         File sites_only_vcf_index
 
         String prefix
+        # SNP model --max-gaussians (default 4). Exposed so small / low-variance
+        # callsets (a per-contig scatter can starve the model) can be tuned per run.
+        Int max_gaussians = 4
 
         RuntimeAttr? runtime_attr_override
     }
@@ -674,7 +680,7 @@ task VariantRecalibratorSnp {
                 --trust-all-polymorphic \
                 -an QD -an DP -an FS -an SOR -an MQ \
                 -mode SNP \
-                --max-gaussians 4 \
+                --max-gaussians ~{max_gaussians} \
                 -resource:Brown,known=true,training=true,truth=true,prior=15.0 ~{sites_only_vcf} \
                 -O ~{prefix}.snp_recal \
                 --tranches-file  ~{prefix}.raw.snp.tranches \


### PR DESCRIPTION

## Summary

Adds tooling to validate and benchmark short-read variant-calling pipelines on
small genomes (*Plasmodium falciparum*), plus robustness fixes to the Pf joint-
and single-sample callers. Three new workflows are registered in Dockstore; the
remaining changes harden existing Pf pipelines against small/low-variance-callset
failure modes surfaced while running the validation on Terra.

## What's included

### New: `BenchmarkVCFsSmall` (`wdl/pipelines/TechAgnostic/Utility/BenchmarkVCFsSmall.wdl`)
A cost-optimized truth/eval benchmark for small genomes.
- Stratified SNP/indel precision–recall via `rtg vcfeval`, with per-indel-length-bin
evaluation folded into the main stratifier scatter.
- Avoids the tabix/index crash on empty/sparse `SelectVariants` output by using
uncompressed `.vcf` intermediates and skipping the output index on the indel step.
- Emits a progress line per completed indel bin; keeps indel summary rows in
`bins.tsv` order for stable, diff-able output.

### New: Pf7 reimplementation pipelines (`wdl/pipelines/Z_One_Off_Analyses/`)
- `Pf7JointGenotyping.wdl` — cohort joint genotyping mirroring the Pf7 per-window
path (GenomicsDBImport → GenotypeGVCFs → excise padding → merge), interval
scatter/gather.
- `Pf7SingleSampleVariantCalling.wdl` — single-sample calling; VQSR step made
**optional/best-effort** so a small callset that underfills the model still
yields a gVCF and genotyped VCF instead of failing the workflow.

### Robustness fixes (Pf callers)
- **`Pf7JointGenotyping` — container swap:** `MakeIntervals` used GNU `split -d`
on an Alpine/BusyBox bcftools image (no `-d`), failing immediately. Switched the
shared `bcftools_docker` default to `us.gcr.io/broad-dsp-lrma/lr-basic` (Debian /
GNU coreutils; already used elsewhere in the workflow).
- **`Pf7JointGenotyping` — organellar contigs:** `MakeIntervals` tiled the full
reference `.fai`, so the apicoplast/mitochondrion contigs produced genotyping
windows that GenomicsDBImport rejects (mito is shorter than one padded window).
Added `Array[String] contigs_to_exclude = ["Pf3D7_API_v3","Pf3D7_MIT_v3"]`,
threaded into the tiling step. Nuclear-only joint calling; default preserves prior
behavior for other contigs.
- **Pf_Niare VQSR — `--max-gaussians` parameterized:** was hard-coded to 4 in the
`VariantRecalibrator{Snp,Indel}` tasks (`Pf_Niare_HaplotypeCaller.wdl`), giving no
way to back the SNP model off on small per-contig callsets that fail to converge
("insufficient variance"). Exposed `snp_max_gaussians` / `indel_max_gaussians`
(default 4) on `SRJointCallGVCFsWithGenomicsDB_Pf_Niare_VQSR` and
`SRWholeGenome_Pf_Niare_VQSR`, threaded to the recalibrator tasks.

## Dockstore
Registers `BenchmarkVCFsSmall`, `Pf7JointGenotyping`, and
`Pf7SingleSampleVariantCalling` in `.dockstore.yml` (task libraries unchanged).

## Validation
Every changed `.wdl` validated with **both** `womtool validate` (Cromwell source of
truth — all `Success!`) and `miniwdl check --strict` (no new warnings beyond
pre-existing `ls`/quoting shellcheck lint). Exercised end-to-end on the
`broad-firecloud-dsde-methods/malaria_variant_calling_validation` Terra workspace
across the pfcrosses, pfcrosses_v2, sr_fiddock, and niare2023 truth sets.
